### PR TITLE
Added list_of helper

### DIFF
--- a/lib/slim.rb
+++ b/lib/slim.rb
@@ -2,40 +2,21 @@
 
 require 'temple'
 require 'tilt'
+require 'slim/parser'
+require 'slim/filter'
+require 'slim/end_inserter'
+require 'slim/compiler'
+require 'slim/engine'
+require 'slim/template'
+require 'slim/helpers'
 
 begin
   require 'escape_utils'
 rescue LoadError
 end
 
-require 'slim/parser'
-require 'slim/end_inserter'
-require 'slim/compiler'
-require 'slim/engine'
-require 'slim/template'
-
 module Slim
-  class << self
-    def version
-      Slim::VERSION
-    end
-
-    if defined?(EscapeUtils)
-      def escape_html(html)
-        EscapeUtils.escape_html(html.to_s)
-      end
-    else
-      ESCAPE_HTML = {
-        '&' => '&amp;',
-        '"' => '&quot;',
-        '<' => '&lt;',
-        '>' => '&gt;',
-        '/' => '&#47;',
-      }
-
-      def escape_html(html)
-        html.to_s.gsub(/[&\"<>\/]/, ESCAPE_HTML)
-      end
-    end
+  def self.version
+    Slim::VERSION
   end
 end

--- a/lib/slim/end_inserter.rb
+++ b/lib/slim/end_inserter.rb
@@ -7,13 +7,8 @@ module Slim
   # However, the parser is not smart enough (and that's a good thing) to
   # automatically insert end's where they are needed. Luckily, this filter
   # does *exactly* that (and it does it well!)
-  class EndInserter
-    include Temple::Utils
+  class EndInserter < Filter
     ELSE_CONTROL_WORDS = /^(else|elsif|when)\b/
-
-    def initialize(options = {})
-      @options = options
-    end
 
     def compile(exp)
       if exp[0] == :slim
@@ -27,14 +22,6 @@ module Slim
       else
         exp
       end
-    end
-
-    def on_tag(name, attrs, content)
-      [:slim, :tag, name, attrs, compile(content)]
-    end
-
-    def on_control(str, content)
-      [:slim, :control, str, compile(content)]
     end
 
     def on_multi(*exps)

--- a/lib/slim/engine.rb
+++ b/lib/slim/engine.rb
@@ -3,19 +3,19 @@ module Slim
     use Slim::Parser
     use Slim::EndInserter
     use Slim::Compiler
+    #use Slim::Debugger
     use Temple::HTML::Fast, :format, :attr_wrapper => '"', :format => :html5
     filter :MultiFlattener
     filter :StaticMerger
     filter :DynamicInliner
     generator :ArrayBuffer
 
-    def self.new(options = {})
-      if options.respond_to?(:each_line)
-        Template.new { options }
+    def self.new(*args)
+      if args.first.respond_to?(:each_line)
+        Template.new(Hash === args.last ? args.last : {}) { args.first }
       else
         super
       end
     end
   end
 end
-

--- a/lib/slim/filter.rb
+++ b/lib/slim/filter.rb
@@ -1,0 +1,43 @@
+module Slim
+  # Abstract filter which does nothing
+  class Filter
+    include Temple::Utils
+
+    def initialize(options = {})
+      @options = options
+    end
+
+    def compile(exp)
+      if exp[0] == :slim
+        _, type, *args = exp
+      else
+        type, *args = exp
+      end
+
+      if respond_to?("on_#{type}")
+        send("on_#{type}", *args)
+      else
+        exp
+      end
+    end
+
+    def on_control(code, content)
+      [:slim, :control, code, compile(content)]
+    end
+
+    def on_tag(name, attrs, content)
+      [:slim, :tag, name, attrs, compile(content)]
+    end
+
+    def on_multi(*exps)
+      [:multi, *exps.map { |exp| compile(exp) }]
+    end
+  end
+
+  class Debugger < Filter
+    def compile(exp)
+      puts exp.inspect
+      exp
+    end
+  end
+end

--- a/lib/slim/helpers.rb
+++ b/lib/slim/helpers.rb
@@ -1,0 +1,34 @@
+module Slim
+  module Helpers
+    def list_of(enum, &block)
+      enum.map do |i|
+        "<li>#{yield(i)}</li>"
+      end.join("\n")
+    end
+
+    if defined?(EscapeUtils)
+      def escape_html(html)
+        EscapeUtils.escape_html(html.to_s)
+      end
+    elsif RUBY_VERSION > '1.9'
+      ESCAPE_HTML = {
+        '&' => '&amp;',
+        '"' => '&quot;',
+        '<' => '&lt;',
+        '>' => '&gt;',
+        '/' => '&#47;',
+      }
+
+      def escape_html(html)
+        html.to_s.gsub(/[&\"<>\/]/, ESCAPE_HTML)
+      end
+    else
+      def escape_html(html)
+        # Ruby, you suck!
+        html.to_s.gsub(/&/n, '&amp;').gsub(/\"/n, '&quot;').gsub(/>/n, '&gt;').gsub(/</n, '&lt;').gsub(/\//, '&#47;')
+      end
+    end
+
+    module_function :escape_html
+  end
+end

--- a/lib/slim/template.rb
+++ b/lib/slim/template.rb
@@ -4,6 +4,11 @@ module Slim
       @src = Engine.new(options).compile(data)
     end
 
+    def evaluate(scope, locals, &block)
+      scope.instance_eval { extend Slim::Helpers } if options[:helpers]
+      super
+    end
+
     def precompiled_template(locals)
       @src
     end
@@ -11,4 +16,3 @@ module Slim
 
   Tilt.register 'slim', Template
 end
-

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -28,8 +28,11 @@ class Env
 
   def hello_world(text = "Hello World from @env", opts = {})
     text << opts.to_a * " " if opts.any?
-    yield if block_given?
-    text
+    if block_given?
+      "#{text} #{yield} #{text}"
+    else
+      text
+    end
   end
 
   def in_keyword

--- a/test/slim/test_code_blocks.rb
+++ b/test/slim/test_code_blocks.rb
@@ -8,7 +8,7 @@ p
     | Hello from within a block!
 HTML
 
-    expected = "<p>Hello from within a block!Hello Ruby!</p>"
+    expected = "<p>Hello Ruby! Hello from within a block! Hello Ruby!</p>"
 
     assert_equal expected, Slim::Engine.new(string).render(@env)
   end
@@ -20,7 +20,7 @@ p
     = hello_world "Hello from within a block! "
 HTML
 
-    expected = "<p>Hello from within a block! Hello Ruby!</p>"
+    expected = "<p>Hello Ruby! Hello from within a block!  Hello Ruby!</p>"
 
     assert_equal expected, Slim::Engine.new(string).render(@env)
   end

--- a/test/slim/test_helpers.rb
+++ b/test/slim/test_helpers.rb
@@ -1,0 +1,12 @@
+class TestSlimHelpers < TestSlim
+  def test_list_of
+    string = <<HTML
+== list_of([1, 2, 3]) do |i|
+  = i
+HTML
+
+    expected = "<li>1</li>\n<li>2</li>\n<li>3</li>"
+
+    assert_equal expected, Slim::Engine.new(string, :helpers => true).render(@env)
+  end
+end


### PR DESCRIPTION
- testcases added
- tested with 1.8.7 and 1.9.1
- helpers are added to the scope if option :helpers is set for the template
- abstract filter class Slim::Filter added
- escaped_output & output are now one type: [:slim, :output, escape boolean, code, content]

this contains the code of the gist by judofyr (issue #8) to support capturing (https://gist.github.com/4082cc8c0eeb6b16c52f)

About the escape_utils thing: It is just a fallback in case escape_utils is not installed. some installations do not allow native extensions (jruby did not). That's my reason.
But I think temple should do the escaping, maybe supported as a core command.
