### PR TITLE
Do no require space behind tag

### DIFF
--- a/test/slim/test_code_output.rb
+++ b/test/slim/test_code_output.rb
@@ -72,6 +72,33 @@ p = hash[:a]
     assert_html '<p>The letter a</p>', source
   end
 
+  def test_tag_output_without_space
+    source = %q{
+p= hello_world
+p=hello_world
+}
+
+    assert_html '<p>Hello World from @env</p><p>Hello World from @env</p>', source
+  end
+
+  def test_class_output_without_space
+    source = %q{
+.test=hello_world
+#test==hello_world
+}
+
+    assert_html '<div class="test">Hello World from @env</div><div id="test">Hello World from @env</div>', source
+  end
+
+  def test_attribute_output_without_space
+    source = %q{
+p id="test"=hello_world
+p(id="test")==hello_world
+}
+
+    assert_html '<p id="test">Hello World from @env</p><p id="test">Hello World from @env</p>', source
+  end
+
   def test_render_with_backslash_end
     source = %q{
 p = \


### PR DESCRIPTION
Unfortunately there is this ruby version check needed because 1.8 doesn't handle the unicode regexes
