### PR TITLE
Allow for bypassing of escaping in attributes

### DIFF
--- a/lib/slim/parser.rb
+++ b/lib/slim/parser.rb
@@ -304,8 +304,10 @@ module Slim
           attributes << [key, [:slim, :text, $1[1..-2]]]
         else
           # Value is ruby code
+          escape = line[0] != ?=
+          line = line[1..-1] unless escape
           line, value = parse_ruby_attribute(orig_line, line, lineno, delimiter)
-          attributes << [key, [:slim, :output, true, value, [:multi]]]
+          attributes << [key, [:slim, :output, escape, value, [:multi]]]
         end
       end
 

--- a/test/slim/test_code_evaluation.rb
+++ b/test/slim/test_code_evaluation.rb
@@ -90,6 +90,14 @@ form(method='post' action=action_path(:page, :save))
     assert_html '<form action="&#47;action-page-save" method="post"></form>', source
   end
 
+  def test_bypassing_escape_in_attribute
+    source = %q{
+form action==action_path(:page, :save) method='post'
+}
+
+    assert_html '<form action="/action-page-save" method="post"></form>', source
+  end
+
   def test_hash_call_in_attribute_without_quotes
     source = %q{
 p id=hash[:a] Test it


### PR DESCRIPTION
If using a method that already escapes the string or a variable that's already escaped, it's useful to be able to bypass the attribute escaping so you don't end up having it escaped twice.
