### PR TITLE
Tweak travis-ci.org matrix a bit 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 rvm:
   - 1.8.7
   - 1.9.2
+  - 1.9.3
   - ruby-head
-  - ree
   - jruby
-  - rbx
   - rbx-2.0
 env:
   - "TASK=test"


### PR DESCRIPTION
- REE is just 1.8.7. For projects that go over 20 rows in the build matrix, we suggest that REE is not included
- rbx-2.0 will soon become rbx (master) so rbx is basically obsolete now
- we provide 1.9.3[-preview1]
