### PR TITLE
Add stylus support

### DIFF
--- a/lib/slim/embedded_engine.rb
+++ b/lib/slim/embedded_engine.rb
@@ -186,6 +186,7 @@ module Slim
     register :less,       TagEngine,  :tag => :style,  :attributes => { :type => 'text/css' },         :engine => StaticTiltEngine
     register :sass,       TagEngine,  :pretty, :tag => :style, :attributes => { :type => 'text/css' }, :engine => SassEngine
     register :scss,       TagEngine,  :pretty, :tag => :style, :attributes => { :type => 'text/css' }, :engine => SassEngine
+    register :styl,       TagEngine,  :tag => :style,  :attributes => { :type => 'text/css' },         :engine => StaticTiltEngine
 
     # These engines are precompiled, code is embedded
     register :erb,        ERBEngine

--- a/slim.gemspec
+++ b/slim.gemspec
@@ -23,9 +23,10 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('tilt', ['~> 1.3.3'])
 
   s.add_development_dependency('rake', ['>= 0.8.7'])
-  s.add_development_dependency('sass', ['>= 3.1.0'])
   s.add_development_dependency('minitest', ['>= 0'])
-  s.add_development_dependency('kramdown', ['>= 0'])
-  s.add_development_dependency('creole', ['>= 0'])
   s.add_development_dependency('builder', ['>= 0'])
+  s.add_development_dependency('creole', ['>= 0'])
+  s.add_development_dependency('kramdown', ['>= 0'])
+  s.add_development_dependency('stylus', ['>= 0'])
+  s.add_development_dependency('sass', ['>= 3.1.0'])
 end

--- a/test/slim/test_embedded_engines.rb
+++ b/test/slim/test_embedded_engines.rb
@@ -1,4 +1,5 @@
 require 'helper'
+require 'stylus'
 
 class TestSlimEmbeddedEngines < TestSlim
   def test_render_with_erb
@@ -107,6 +108,16 @@ scss:
   body { color: $color; }
 }
     assert_html "<style type=\"text/css\">body{color:red}</style>", source
+  end
+
+  def test_render_with_styl
+    source = %q{
+styl:
+  red = hotpink
+  body
+    color red
+}
+    assert_html "<style type=\"text/css\">body {\n  color: #ff69b4;\n}\n</style>", source
   end
 
   def test_disabled_embedded_engine


### PR DESCRIPTION
[ruby-stylus](https://github.com/lucasmazza/ruby-stylus) is the tilt engine for [stylus](http://learnboost.github.com/stylus/).
