### PR TITLE
do not blow up when required in an rails2 app

### DIFF
--- a/lib/slim/template.rb
+++ b/lib/slim/template.rb
@@ -6,7 +6,8 @@ module Slim
   if Object.const_defined?(:Rails)
     # Rails template implementation for Slim
     # @api public
-    RailsTemplate = Temple::Templates::Rails(Slim::Engine,
+    begin
+      RailsTemplate = Temple::Templates::Rails(Slim::Engine,
                                              :register_as => :slim,
                                              # Use rails-specific generator. This is necessary
                                              # to support block capturing and streaming.
@@ -15,5 +16,8 @@ module Slim
                                              # Rails takes care of the capturing by itself.
                                              :disable_capture => true,
                                              :streaming => Object.const_defined?(:Fiber))
+    rescue RuntimeError => e
+      warn "Failed to load RailsTemplate #{e.message}"
+    end
   end
 end


### PR DESCRIPTION
temple:rails blows up when loaded in a rails2 app,
this way It wont parse your view temples, but it can be used to parse static files and the like
