### PR TITLE
Fixed a parsing bug that's responsible for matching Splat attributes

### DIFF
--- a/lib/slim/parser.rb
+++ b/lib/slim/parser.rb
@@ -351,7 +351,7 @@ module Slim
 
       while true
         case @line
-        when /\A\s*\*(?=[^\s]+)/
+        when /\A\s*\*(?=\{)/
           # Splat attribute
           @line = $'
           attributes << [:slim, :splat, parse_ruby_code(delimiter)]


### PR DESCRIPTION
Fixed a parsing bug that's responsible for matching Splat attributes
more detail -> #279
