### PR TITLE
Add explicit column number to SyntaxError.to_s

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,7 @@ master
   * Parser: check for missing closing quote in quoted attributes
   * Use new temple option validation to make Slim configuration more user friendly.
   * Support thread options Slim::Engine.with_options which especially useful for Rails
+  * Add explicit column number to SyntaxError.to_s
 
 1.3.0
 

--- a/lib/slim/parser.rb
+++ b/lib/slim/parser.rb
@@ -27,7 +27,7 @@ module Slim
         line = @line.strip
         column = @column + line.size - @line.size
         %{#{error}
-  #{file}, Line #{lineno}
+  #{file}, Line #{lineno}, Column #{@column}
     #{line}
     #{' ' * column}^
 }


### PR DESCRIPTION
The ^ column marker in the current output ignores any leading whitespace, so I
am unable to use it to calculate the column to highlight the column in vim. This
patch adds an explicit column number.
