### PR TITLE
Add explicit column number to SyntaxError.to_s

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,7 @@ master
   * Parser: check for missing closing quote in quoted attributes
   * Use new temple option validation to make Slim configuration more user friendly.
   * Support thread options Slim::Engine.with_options which especially useful for Rails
+  * Add explicit column number to SyntaxError.to_s
 
 1.3.0
 

--- a/lib/slim/parser.rb
+++ b/lib/slim/parser.rb
@@ -27,7 +27,7 @@ module Slim
         line = @line.strip
         column = @column + line.size - @line.size
         %{#{error}
-  #{file}, Line #{lineno}
+  #{file}, Line #{lineno}, Column #{@column}
     #{line}
     #{' ' * column}^
 }

--- a/test/core/test_parser_errors.rb
+++ b/test/core/test_parser_errors.rb
@@ -7,7 +7,7 @@ doctype 5
   div Invalid
 }
 
-    assert_syntax_error "Unexpected indentation\n  test.slim, Line 3\n    div Invalid\n    ^\n", source, :file => 'test.slim'
+    assert_syntax_error "Unexpected indentation\n  test.slim, Line 3, Column 2\n    div Invalid\n    ^\n", source, :file => 'test.slim'
   end
 
   def test_unexpected_indentation
@@ -16,7 +16,7 @@ doctype 5
   div Invalid
 }
 
-    assert_syntax_error "Unexpected indentation\n  (__TEMPLATE__), Line 3\n    div Invalid\n    ^\n", source
+    assert_syntax_error "Unexpected indentation\n  (__TEMPLATE__), Line 3, Column 2\n    div Invalid\n    ^\n", source
   end
 
   def test_unexpected_text_indentation
@@ -26,7 +26,7 @@ p
    text
 }
 
-    assert_syntax_error "Text line not indented deep enough.\nThe first text line defines the necessary text indentation.\n  (__TEMPLATE__), Line 4\n    text\n    ^\n", source
+    assert_syntax_error "Text line not indented deep enough.\nThe first text line defines the necessary text indentation.\n  (__TEMPLATE__), Line 4, Column 3\n    text\n    ^\n", source
   end
 
   def test_unexpected_text_indentation_in_tag
@@ -42,7 +42,7 @@ ul
       li b
 }
 
-    assert_syntax_error "Text line not indented deep enough.\nThe first text line defines the necessary text indentation.\nAre you trying to nest a child tag in a tag containing text? Use | for the text block!\n  (__TEMPLATE__), Line 4\n    ul\n    ^\n", source
+    assert_syntax_error "Text line not indented deep enough.\nThe first text line defines the necessary text indentation.\nAre you trying to nest a child tag in a tag containing text? Use | for the text block!\n  (__TEMPLATE__), Line 4, Column 4\n    ul\n    ^\n", source
   end
 
   def test_malformed_indentation
@@ -52,7 +52,7 @@ p
  div Invalid
 }
 
-    assert_syntax_error "Malformed indentation\n  (__TEMPLATE__), Line 4\n    div Invalid\n    ^\n", source
+    assert_syntax_error "Malformed indentation\n  (__TEMPLATE__), Line 4, Column 1\n    div Invalid\n    ^\n", source
   end
 
   def test_unknown_line_indicator
@@ -64,7 +64,7 @@ p
   ?invalid
 }
 
-    assert_syntax_error "Unknown line indicator\n  (__TEMPLATE__), Line 6\n    ?invalid\n    ^\n", source
+    assert_syntax_error "Unknown line indicator\n  (__TEMPLATE__), Line 6, Column 2\n    ?invalid\n    ^\n", source
   end
 
   def test_expected_closing_delimiter
@@ -73,7 +73,7 @@ p
   img(src="img.jpg" title={title}
 }
 
-    assert_syntax_error "Expected closing delimiter )\n  (__TEMPLATE__), Line 3\n    img(src=\"img.jpg\" title={title}\n                                   ^\n", source
+    assert_syntax_error "Expected closing delimiter )\n  (__TEMPLATE__), Line 3, Column 33\n    img(src=\"img.jpg\" title={title}\n                                   ^\n", source
   end
 
   def test_expected_closing_quote
@@ -82,7 +82,7 @@ p
   img(src="img.jpg
 }
 
-    assert_syntax_error "Expected closing quote \"\n  (__TEMPLATE__), Line 3\n    img(src=\"img.jpg\n                    ^\n", source
+    assert_syntax_error "Expected closing quote \"\n  (__TEMPLATE__), Line 3, Column 18\n    img(src=\"img.jpg\n                    ^\n", source
   end
 
   def test_expected_closing_attribute_delimiter
@@ -91,7 +91,7 @@ p
   img src=[hash[1] + hash[2]
 }
 
-    assert_syntax_error "Expected closing delimiter ]\n  (__TEMPLATE__), Line 3\n    img src=[hash[1] + hash[2]\n                              ^\n", source
+    assert_syntax_error "Expected closing delimiter ]\n  (__TEMPLATE__), Line 3, Column 28\n    img src=[hash[1] + hash[2]\n                              ^\n", source
   end
 
   def test_expected_attribute
@@ -100,7 +100,7 @@ p
   img(src='img.png' whatsthis?!)
 }
 
-    assert_syntax_error "Expected attribute\n  (__TEMPLATE__), Line 3\n    img(src='img.png' whatsthis?!)\n                      ^\n", source
+    assert_syntax_error "Expected attribute\n  (__TEMPLATE__), Line 3, Column 20\n    img(src='img.png' whatsthis?!)\n                      ^\n", source
   end
 
   def test_invalid_empty_attribute
@@ -109,7 +109,7 @@ p
   img{src= }
 }
 
-    assert_syntax_error "Invalid empty attribute\n  (__TEMPLATE__), Line 3\n    img{src= }\n            ^\n", source
+    assert_syntax_error "Invalid empty attribute\n  (__TEMPLATE__), Line 3, Column 10\n    img{src= }\n            ^\n", source
   end
 
   def test_invalid_empty_attribute2
@@ -118,7 +118,7 @@ p
   img{src=}
 }
 
-    assert_syntax_error "Invalid empty attribute\n  (__TEMPLATE__), Line 3\n    img{src=}\n            ^\n", source
+    assert_syntax_error "Invalid empty attribute\n  (__TEMPLATE__), Line 3, Column 10\n    img{src=}\n            ^\n", source
   end
 
   def test_invalid_empty_attribute3
@@ -127,7 +127,7 @@ p
   img src=
 }
 
-    assert_syntax_error "Invalid empty attribute\n  (__TEMPLATE__), Line 3\n    img src=\n            ^\n", source
+    assert_syntax_error "Invalid empty attribute\n  (__TEMPLATE__), Line 3, Column 10\n    img src=\n            ^\n", source
   end
 
   def test_missing_tag_in_block_expansion
@@ -135,18 +135,18 @@ p
 html: body:
 }
 
-    assert_syntax_error "Expected tag\n  (__TEMPLATE__), Line 2\n    html: body:\n               ^\n", source
+    assert_syntax_error "Expected tag\n  (__TEMPLATE__), Line 2, Column 11\n    html: body:\n               ^\n", source
   end
 
   def test_invalid_tag_in_block_expansion
     source = %{
 html: body: /comment
 }
-    assert_syntax_error "Expected tag\n  (__TEMPLATE__), Line 2\n    html: body: /comment\n                ^\n", source
+    assert_syntax_error "Expected tag\n  (__TEMPLATE__), Line 2, Column 12\n    html: body: /comment\n                ^\n", source
 
     source = %{
 html: body:/comment
 }
-    assert_syntax_error "Expected tag\n  (__TEMPLATE__), Line 2\n    html: body:/comment\n               ^\n", source
+    assert_syntax_error "Expected tag\n  (__TEMPLATE__), Line 2, Column 11\n    html: body:/comment\n               ^\n", source
   end
 end


### PR DESCRIPTION
The ^ column marker in the current output ignores any leading whitespace, so I
am unable to use it to calculate the column to highlight the column in vim. This
patch adds an explicit column number.
## 

I had to edit my Rakefile to `require 'bundler/setup'` for it to see the bundler version of temple, but I left that out of the commit as I assume you know better than me what you're doing there.

```
rake test
/Users/rb/.rvm/rubies/ruby-1.9.3-p194/bin/ruby -I"lib:lib:test/core" -I"/Users/rb/.rvm/gems/ruby-1.9.3-p194@global/gems/rake-0.9.2.2/lib" "/Users/rb/.rvm/gems/ruby-1.9.3-p194@global/gems/rake-0.9.2.2/lib/rake/rake_test_loader.rb" "test/core/test_code_blocks.rb" "test/core/test_code_escaping.rb" "test/core/test_code_evaluation.rb" "test/core/test_code_output.rb" "test/core/test_code_structure.rb" "test/core/test_embedded_engines.rb" "test/core/test_encoding.rb" "test/core/test_html_escaping.rb" "test/core/test_html_structure.rb" "test/core/test_parser_errors.rb" "test/core/test_pretty.rb" "test/core/test_ruby_errors.rb" "test/core/test_slim_template.rb" "test/core/test_text_interpolation.rb" "test/core/test_thread_options.rb" 
Run options: --seed 39728

# Running tests:

......................................................................................................................................................................................................................

Finished tests in 1.091355s, 196.0865 tests/s, 224.4916 assertions/s.

214 tests, 245 assertions, 0 failures, 0 errors, 0 skips
/Users/rb/.rvm/rubies/ruby-1.9.3-p194/bin/ruby -I"lib:lib:test/core" -I"/Users/rb/.rvm/gems/ruby-1.9.3-p194@global/gems/rake-0.9.2.2/lib" "/Users/rb/.rvm/gems/ruby-1.9.3-p194@global/gems/rake-0.9.2.2/lib/rake/rake_test_loader.rb" "test/logic_less/test_logic_less.rb" "test/logic_less/test_wrapper.rb" 
Run options: --seed 11640

# Running tests:

.........

Finished tests in 0.050753s, 177.3294 tests/s, 177.3294 assertions/s.

9 tests, 9 assertions, 0 failures, 0 errors, 0 skips
/Users/rb/.rvm/rubies/ruby-1.9.3-p194/bin/ruby -I"lib:lib:test/core" -I"/Users/rb/.rvm/gems/ruby-1.9.3-p194@global/gems/rake-0.9.2.2/lib" "/Users/rb/.rvm/gems/ruby-1.9.3-p194@global/gems/rake-0.9.2.2/lib/rake/rake_test_loader.rb" "test/translator/test_translator.rb" 
Run options: --seed 43217

# Running tests:

....

Finished tests in 0.118099s, 33.8699 tests/s, 76.2072 assertions/s.

4 tests, 9 assertions, 0 failures, 0 errors, 0 skips
```
