### PR TITLE
Fix problem with Sinatra and Padrino

### DIFF
--- a/lib/slim/engine.rb
+++ b/lib/slim/engine.rb
@@ -10,7 +10,9 @@ module Slim
                    :attr_wrapper => '"',
                    :attr_delimiter => {'class' => ' '},
                    :generator => Temple::Generators::ArrayBuffer,
-                   :default_tag => 'div'
+                   :default_tag => 'div',
+                   :buffer => '@_out_buf', 
+                   :outvar => '@_out_buf'
 
     # TODO: Remove these options in 1.4.0
     define_deprecated_options :remove_empty_attrs, :chain


### PR DESCRIPTION
Hi,

after you changed temple dependency now Sinatra is unable to set the `:outvar`
[see here](https://github.com/sinatra/sinatra/blob/master/lib/sinatra/base.rb#L697)

also Padrino has some problems but with `:buffer`.

I don't know what are Temple defaults, but any can be fine to prevent the error

``` rb
Silm::Engine has not default options for :outvar
```
