### PR TITLE
Fix NameError during `require 'slim'`

### DIFF
--- a/lib/slim/template.rb
+++ b/lib/slim/template.rb
@@ -3,7 +3,7 @@ module Slim
   # @api public
   Template = Temple::Templates::Tilt(Slim::Engine, :register_as => :slim)
 
-  if Object.const_defined?(:Rails)
+  if Object.const_defined?(:Rails) && Object.const_defined?(:ActionView)
     # Rails template implementation for Slim
     # @api public
     RailsTemplate = Temple::Templates::Rails(Slim::Engine,


### PR DESCRIPTION
Checking if `Rails` is defined is not a good test of whether Rails is loaded, since many gems use the Rails namespace.

e.g. this will throw an NameError:

``` ruby
require "active_resource/railtie"
require "slim"
```
