### PR TITLE
register embedded engine for asciidoc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem 'minitest'
 gem 'kramdown'
 gem 'creole'
 gem 'builder'
+gem 'asciidoctor'
 
 if ENV['TASK'] == 'bench'
   gem 'erubis'

--- a/README.md
+++ b/README.md
@@ -573,6 +573,7 @@ Supported engines:
 <tr><td>less:</td><td>less</td><td>Compile time</td><td>Embed less css code and wrap in style tag</td></tr>
 <tr><td>styl:</td><td>styl</td><td>Compile time</td><td>Embed stylus css code and wrap in style tag</td></tr>
 <tr><td>coffee:</td><td>coffee-script</td><td>Compile time</td><td>Compile coffee script code and wrap in script tag</td></tr>
+<tr><td>asciidoc:</td><td>asciidoctor</td><td>Compile time + Interpolation</td><td>Compile AsciiDoc code and interpolate #\{variables} in text</td></tr>
 <tr><td>markdown:</td><td>redcarpet/rdiscount/kramdown</td><td>Compile time + Interpolation</td><td>Compile markdown code and interpolate #\{variables} in text</td></tr>
 <tr><td>textile:</td><td>redcloth</td><td>Compile time + Interpolation</td><td>Compile textile code and interpolate #\{variables} in text</td></tr>
 <tr><td>creole:</td><td>creole</td><td>Compile time + Interpolation</td><td>Compile creole code and interpolate #\{variables} in text</td></tr>
@@ -587,6 +588,10 @@ Supported engines:
 The embedded engines can be configured in Slim by setting the options directly on the `Slim::Embedded` filter. Example:
 
     Slim::Embedded.default_options[:markdown] = {:auto_ids => false}
+
+Similarly, you can configure the AsciiDoc engine as follows:
+
+    Slim::Embedded.default_options[:asciidoc] = {:header_footer => true, :attributes => {'sectids!' => ''}}
 
 ## Configuring Slim
 

--- a/lib/slim/embedded.rb
+++ b/lib/slim/embedded.rb
@@ -241,6 +241,7 @@ module Slim
     end
 
     # These engines are executed at compile time, embedded ruby is interpolated
+    register :asciidoc,   InterpolateTiltEngine
     register :markdown,   InterpolateTiltEngine
     register :textile,    InterpolateTiltEngine
     register :rdoc,       InterpolateTiltEngine

--- a/test/core/test_embedded_engines.rb
+++ b/test/core/test_embedded_engines.rb
@@ -14,6 +14,57 @@ p
     assert_html "<p><b>Hello from BEFORE ERB BLOCK!</b>\nSecond Line!\ntrue</p>", source
   end
 
+  def test_wip_render_with_asciidoc
+    source = %q{
+asciidoc:
+  == Header
+  Hello from #{"AsciiDoc!"}
+
+  #{1+2}
+
+  * one
+  * two
+}
+
+    expected = <<-EOS
+<div class="sect1">
+<h2 id="_header">Header</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Hello from AsciiDoc!</p>
+</div>
+<div class="paragraph">
+<p>3</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>one</p>
+</li>
+<li>
+<p>two</p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+    EOS
+    # render, then remove blank lines and unindent the remaining lines
+    output = render(source).gsub(/^ *(\n|(?=[^ ]))/, '')
+
+    assert_equal expected, output
+
+    Slim::Embedded.with_options(:asciidoc => {:compact => true, :attributes => {'sectids!' => ''}}) do
+      # render, then unindent lines
+      output = render(source).gsub(/^ *(?=[^ ])/, '')
+      assert_equal expected.gsub('<h2 id="_header">', '<h2>'), output
+    end
+
+    # render again, then remove blank lines and unindent the remaining lines
+    output = render(source).gsub(/^ *(\n|(?=[^ ]))/, '')
+    assert_equal expected, output
+  end
+
   def test_render_with_markdown
     source = %q{
 markdown:


### PR DESCRIPTION
- asciidoc content handled by Asciidoctor by way of Tilt 1.3.4

AsciiDoc support was added to Tilt 1.3.4. Therefore, Slim can delegate handling this content to Tilt.
