### PR TITLE
invert output escaping logic if disable_escape is true

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ Same as the single equal sign (`=`), except that it adds a trailing white space.
 
 Same as the single equal sign (`=`), but does not go through the `escape_html` method.
 
+If :disable\_escape is true, then the function of `==` and `=` are reversed.
+
 ### Output without HTML escaping and trailing ws `=='`
 
 Same as the double equal sign (`==`), except that it adds a trailing white space.

--- a/lib/slim/engine.rb
+++ b/lib/slim/engine.rb
@@ -12,7 +12,7 @@ module Slim
                    :generator => Temple::Generators::ArrayBuffer,
                    :default_tag => 'div'
 
-    use Slim::Parser, :file, :tabsize, :encoding, :shortcut, :default_tag
+    use Slim::Parser, :file, :tabsize, :encoding, :shortcut, :default_tag, :disable_escape
     use Slim::Embedded, :enable_engines, :disable_engines, :pretty
     use Slim::Interpolation
     use Slim::Splat::Filter, :merge_attrs, :attr_quote, :sort_attrs, :default_tag, :hyphen_attrs
@@ -23,7 +23,7 @@ module Slim
     use Slim::CodeAttributes, :merge_attrs
     use(:AttributeRemover) { Temple::HTML::AttributeRemover.new(:remove_empty_attrs => options[:merge_attrs].keys) }
     html :Pretty, :format, :attr_quote, :pretty, :indent, :js_wrapper
-    filter :Escapable, :use_html_safe, :disable_escape
+    filter :Escapable, :use_html_safe
     filter :ControlFlow
     filter :MultiFlattener
     use :Optimizer do


### PR DESCRIPTION
Resolves issue #364.

If it's important to retain the functionality of `disable_escape` to disable escaping outright, then I propose introducing a new option `default_escape` for controlling this feature.
