### PR TITLE
Updates readme (Slim 2.0 recommendation typo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A short list of the features...
 __NOTE:__ Slim 2.0 is not yet released, but you can try the preview versions.
 
 If you are already using Slim 1.3 or 1.2 and want to upgrade to the newest version 2.0, you should at first
-upgrade to Slim 1.3.7 which will emit warnings for deprecated features. This way you can easily
+upgrade to Slim 1.3.6 which will emit warnings for deprecated features. This way you can easily
 see if your application is already Slim 2.0 compliant!
 
 Slim 2.0 removes deprecated features from the 1.3 series and cleans up some minor


### PR DESCRIPTION
Presumably this was supposed to be `1.3.6` since `1.3.7` does not exist according to RubyGems or the CHANGES file.
