### PR TITLE
check ::Rails::VERSION instead of ::ActionView

### DIFF
--- a/lib/slim/template.rb
+++ b/lib/slim/template.rb
@@ -3,7 +3,7 @@ module Slim
   # @api public
   Template = Temple::Templates::Tilt(Slim::Engine, :register_as => :slim)
 
-  if defined?(::ActionView)
+  if defined?(::Rails::VERSION)
     # Rails template implementation for Slim
     # @api public
     RailsTemplate = Temple::Templates::Rails(Slim::Engine,


### PR DESCRIPTION
In some cases, `ActionView` is not specific enough. How about we check `Rails::VERSION` instead?

I tracked this error down to the `ActionView` namespace being defined in actionpack:

https://travis-ci.org/mperham/sidekiq/jobs/6200824#L93
