### PR TITLE
Loosen tilt dependency to allow any 1.x version >= 1.3.3

### DIFF
--- a/slim.gemspec
+++ b/slim.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
   s.require_paths = %w(lib)
 
   s.add_runtime_dependency('temple', ['~> 0.6.3'])
-  s.add_runtime_dependency('tilt', ['~> 1.3.3'])
+  s.add_runtime_dependency('tilt', ['~> 1.3', '>= 1.3.3'])
 end


### PR DESCRIPTION
This change allows slim to use tilt version 1.4.0 and any future 1.x version, which ought to be compatible, as long as tilt adheres to Semantic Versioning.
