### PR TITLE
To support 'case-when' statement, modified REGEX for do_inserter

### DIFF
--- a/lib/slim/do_inserter.rb
+++ b/lib/slim/do_inserter.rb
@@ -7,7 +7,7 @@ module Slim
   #
   # @api private
   class DoInserter < Filter
-    BLOCK_REGEX = /(\A(if|unless|else|elsif|when|begin|rescue|ensure)\b)|do\s*(\|[^\|]*\|\s*)?\Z/
+    BLOCK_REGEX = /(\A(if|unless|else|elsif|when|begin|rescue|ensure|case)\b)|do\s*(\|[^\|]*\|\s*)?\Z/
 
     # Handle control expression `[:slim, :control, code, content]`
     #


### PR DESCRIPTION
Now we can use this as:
- case variable when value1
  .one
- when value2
  .two
