### PR TITLE
Add :attr_delims option

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ You can use text interpolation in the quoted attributes.
 
 If a delimiter makes the syntax more readable for you,
 you can use the characters `{...}`, `(...)`, `[...]` to wrap the attributes.
+You can configure these symbols (See option `:attr_delims`).
 
     body
       h1(id="logo") = page_logo
@@ -703,6 +704,7 @@ There are a lot of them but the good thing is, that Slim checks the configuratio
 | String | :encoding | "utf-8" | Set encoding of template |
 | String | :default_tag | "div" | Default tag to be used if tag name is omitted |
 | Hash | :shortcut | \{'.' => {:attr => 'class'}, '#' => {:attr => 'id'}} | Attribute shortcuts |
+| Hash | :attr_delims | \{'(' => ')', '[' => ']', '{' => '}'} | Attribute delimiters |
 | Array&lt;Symbol,String&gt; | :enable_engines | nil <i>(All enabled)</i> | List of enabled embedded engines (whitelist) |
 | Array&lt;Symbol,String&gt; | :disable_engines | nil <i>(None disabled)</i> | List of disabled embedded engines (blacklist) |
 | Boolean | :disable_capture | false (true in Rails) | Disable capturing in blocks (blocks write to the default buffer  |

--- a/lib/slim/engine.rb
+++ b/lib/slim/engine.rb
@@ -14,7 +14,7 @@ module Slim
 
     filter :Encoding, :encoding
     filter :RemoveBOM
-    use Slim::Parser, :file, :tabsize, :shortcut, :default_tag
+    use Slim::Parser, :file, :tabsize, :shortcut, :default_tag, :attr_delims
     use Slim::Embedded, :enable_engines, :disable_engines, :pretty
     use Slim::Interpolation
     use Slim::Splat::Filter, :merge_attrs, :attr_quote, :sort_attrs, :default_tag, :hyphen_attrs

--- a/test/core/test_html_structure.rb
+++ b/test/core/test_html_structure.rb
@@ -283,6 +283,26 @@ p(id="marvin" class="martian" data-info="Illudium Q-36")= output_number
     assert_html '<p class="martian" data-info="Illudium Q-36" id="marvin">1337</p>', source
   end
 
+  def test_default_attr_delims_option
+    source = %q{
+p<id="marvin" class="martian" data-info="Illudium Q-36">= output_number
+}
+    Slim::Parser.default_options[:attr_delims].each do |k,v|
+      str = source.sub('<',k).sub('>',v)
+      assert_html '<p class="martian" data-info="Illudium Q-36" id="marvin">1337</p>', str
+    end
+  end
+
+  def test_custom_attr_delims_option
+    source = %q{
+p { foo="bar" }
+}
+
+    assert_html '<p foo="bar"></p>', source
+    assert_html '<p foo="bar"></p>', source, :attr_delims => {'{' => '}'}
+    assert_html '<p>{ foo="bar" }</p>', source, :attr_delims => {'(' => ')', '[' => ']'}
+  end
+
   def test_closed_tag
     source = %q{
 closed/
@@ -358,7 +378,7 @@ p<id="marvin"
 class="martian"
  data-info="Illudium Q-36"> = output_number
 }
-    Slim::Parser::DELIMS.each do |k,v|
+    Slim::Parser.default_options[:attr_delims].each do |k,v|
       str = source.sub('<',k).sub('>',v)
       assert_html '<p class="martian" data-info="Illudium Q-36" id="marvin">1337</p>', str
     end
@@ -370,7 +390,7 @@ p<id="marvin"
   class="martian"
  data-info="Illudium Q-36"> THE space modulator
 }
-    Slim::Parser::DELIMS.each do |k,v|
+    Slim::Parser.default_options[:attr_delims].each do |k,v|
       str = source.sub('<',k).sub('>',v)
       assert_html '<p class="martian" data-info="Illudium Q-36" id="marvin">THE space modulator</p>', str
     end
@@ -383,7 +403,7 @@ p<id="marvin"
 data-info="Illudium Q-36">
   | THE space modulator
 }
-    Slim::Parser::DELIMS.each do |k,v|
+    Slim::Parser.default_options[:attr_delims].each do |k,v|
       str = source.sub('<',k).sub('>',v)
       assert_html '<p class="martian" data-info="Illudium Q-36" id="marvin">THE space modulator</p>', str
     end
@@ -396,7 +416,7 @@ p<id=id_helper
   data-info="Illudium Q-36">
   | THE space modulator
 }
-    Slim::Parser::DELIMS.each do |k,v|
+    Slim::Parser.default_options[:attr_delims].each do |k,v|
       str = source.sub('<',k).sub('>',v)
       assert_html '<p class="martian" data-info="Illudium Q-36" id="notice">THE space modulator</p>', str
     end
@@ -410,7 +430,7 @@ p<id=id_helper
   span.emphasis THE
   |  space modulator
 }
-    Slim::Parser::DELIMS.each do |k,v|
+    Slim::Parser.default_options[:attr_delims].each do |k,v|
       str = source.sub('<',k).sub('>',v)
       assert_html '<p class="martian" data-info="Illudium Q-36" id="notice"><span class="emphasis">THE</span> space modulator</p>', str
     end
@@ -423,7 +443,7 @@ li< id="myid"
 data-info="myinfo">
   a href="link" My Link
 }
-    Slim::Parser::DELIMS.each do |k,v|
+    Slim::Parser.default_options[:attr_delims].each do |k,v|
       str = source.sub('<',k).sub('>',v)
       assert_html '<li class="myclass" data-info="myinfo" id="myid"><a href="link">My Link</a></li>', str
     end


### PR DESCRIPTION
I want to use Slim with AngularJS but run into the problem.
I have this code in my template:

```
div ng-controller="myCtrl"
  p {{ page.content }}
```

And I get this error:

```
Slim::Parser::SyntaxError: Expected attribute
  STDIN, Line 2, Column 5
    p {{ page.content }}
       ^
```

That because Slim uses `{` and `}` symbols as attribute delimiters and there is no way to change it.
I've added new option `:attr_delims` so now I can set option like this:

```
Slim::Engine.set_default_options :attr_delims => {'(' => ')', '[' => ']'}
```

It resolves my problem.
I've added several tests to make sure that nothing broken.
Please, let me know what do you think about this change.
If you don't like it, I will appreciate any advise how to resolve this problem in another way.
