### PR TITLE
Escaping backslash

### DIFF
--- a/lib/slim/interpolation.rb
+++ b/lib/slim/interpolation.rb
@@ -14,6 +14,10 @@ module Slim
       block = [:multi]
       begin
         case string
+          when /\A\\\\/
+          # Escaped backslash
+          block << [:static, '\\']
+          string = $'
         when /\A\\#\{/
           # Escaped interpolation
           block << [:static, '#{']


### PR DESCRIPTION
Allows backslash right before the interpolation:

```
\\#{123}
```

becomes:

```
\123
```
