### PR TITLE
Add text block indicator that preserves newlines

### DIFF
--- a/lib/slim/parser.rb
+++ b/lib/slim/parser.rb
@@ -191,10 +191,9 @@ module Slim
         parse_comment_block
       when /\A([\|'"])( ?)/
         # Found a text block.
-        trailing_ws = $1 == "'" || "\""
         @stacks.last << [:slim, :text, parse_text_block($', @indents.last + $2.size + 1)]
-        @stacks.last << [:static, ' '] if trailing_ws == "'"
-        @stacks.last << [:static, "\n"] if trailing_ws == "\""
+        @stacks.last << [:static, ' '] if $1 == "'"
+        @stacks.last << [:static, "\n"] if $1 == "\"" && Slim::Engine.default_options[:pretty]
       when /\A</
         # Inline html
         block = [:multi]


### PR DESCRIPTION
**Using `"` at the beginning of a line works similarly to `|`, but newlines are preserved in the output (if `:pretty` is set to true).**

Reading Handlebars.js templates, for example, can be difficult when several consecutive lines of {{tags}} get consolidated into a single line. Since `:pretty` is intended to produce easier to read output, it’s useful to have the option to respect the newlines within a text block for this and other scenarios.

This is ignored (i.e. it behaves like `|`) if `:pretty` is set to false, as that seems like expected behavior.
