### PR TITLE
Should fix the travis errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - ruby-head
   - jruby-18mode
   - jruby-19mode
-  - rbx
+  - rbx-2
 env:
   - "TASK=test:core_and_plugins TILT=master"
   - "TASK=test:core_and_plugins TILT=1.3.7"

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,13 @@ if ENV['RAILS']
   end
 end
 
+#Choose minitest 4.7.x for sinatra or rails 3 and 4.0 otherwise go for newer version
+if ENV['SINATRA'] || (ENV['RAILS'] && !ENV['RAILS'].match(/4\.([1-9])(\..*)?/))
+  gem 'minitest', '~> 4.7.4'
+else
+  gem 'minitest', '~> 5.1'
+end
+
 if ENV['SINATRA']
   gem 'rack-test'
   if ENV['SINATRA'] == 'master'
@@ -40,7 +47,6 @@ gem 'creole'
 gem 'builder'
 gem 'asciidoctor'
 gem 'org-ruby'
-gem 'minitest', '~> 4.7.4'
 
 if ENV['TASK'] == 'bench'
   gem 'erubis'

--- a/test/core/test_embedded_engines.rb
+++ b/test/core/test_embedded_engines.rb
@@ -1,4 +1,5 @@
 require 'helper'
+require 'erb' #asciidoctor fail to load it randomly
 
 class TestSlimEmbeddedEngines < TestSlim
   def test_render_with_erb

--- a/test/rails/test/test_slim.rb
+++ b/test/rails/test/test_slim.rb
@@ -46,7 +46,9 @@ class TestSlim < ActionDispatch::IntegrationTest
     assert_html "<h1>Hello Slim!</h1><p>With a partial!</p>"
   end
 
-  if ::Rails::VERSION::MAJOR == 3 && ::Rails::VERSION::MINOR >= 1 && Object.const_defined?(:Fiber)
+  #Disable streaming testing for rails 3.x and on jruby
+  if ::Rails::VERSION::MAJOR >= 4 ||
+      (::Rails::VERSION::MAJOR == 3 && ::Rails::VERSION::MINOR >= 1 && Object.const_defined?(:Fiber))
     puts 'Streaming test enabled'
     test "streaming" do
       get "slim/streaming"


### PR DESCRIPTION
This should fix all travis errors
Details:
- `.travis.yml` travis has a bug with `rbx` "_When using Rubinius, there's currently an issue with selecting the correct version in RVM in our build environment, but only when specifying rbx as your version. As a workaround, specify rbx-2 instead._"
- `Gemfile` checking if the rails  environment is either master or more than 4.1(regex) to require minitest 5.1 otherwise keep the old minitest version
- `slim_test.rb`: there was a problem with rails 3.1.x and jruby-mode19 when streaming
- `gitignore`: I'am using rubymine just added the config folder to gitignore
