### PR TITLE
Drop unused variable to make Slim warning-clean

### DIFF
--- a/lib/slim/parser.rb
+++ b/lib/slim/parser.rb
@@ -338,7 +338,6 @@ module Slim
         # Handle output code
         @line = $'
         trailing_ws2 = $2.include?('\'') || $2.include?('>')
-        leading_ws2 = $2.include?('<')
         block = [:multi]
         @stacks.last.insert(-2, [:static, ' ']) if !leading_ws && $2.include?('<')
         tag << [:slim, :output, $1 != '=', parse_broken_line, block]


### PR DESCRIPTION
Sometime recently Slim stopped being warning-clean; this fixes it.

Running tests with warnings enabled is a good practice and helps me now-and-then, so it would be perfect if the libraries my projects depend on were warning-clean. This makes Slim a warning-clean library again. :)
