### PR TITLE
Fix compatibility with Rails 4 browser error reporting

### DIFF
--- a/lib/slim/parser.rb
+++ b/lib/slim/parser.rb
@@ -482,6 +482,9 @@ module Slim
     def syntax_error!(message)
       raise SyntaxError.new(message, options[:file], @orig_line, @lineno,
                             @orig_line && @line ? @orig_line.size - @line.size : 0)
+    rescue SyntaxError => ex
+      ex.backtrace.unshift "#{options[:file]}:#{@lineno}"
+      raise
     end
 
     def expect_next_line

--- a/test/core/helper.rb
+++ b/test/core/helper.rb
@@ -46,6 +46,8 @@ class TestSlim < MiniTest::Unit::TestCase
     raise 'Syntax error expected'
   rescue Slim::Parser::SyntaxError => ex
     assert_equal message, ex.message
+    message =~ /([^\s]+), Line (\d+)/
+    assert_backtrace ex, "#{$1}:#{$2}"
   end
 
   def assert_ruby_error(error, from, source, options = {})
@@ -58,12 +60,12 @@ class TestSlim < MiniTest::Unit::TestCase
   def assert_backtrace(ex, from)
     if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx'
       # HACK: Rubinius stack trace sometimes has one entry more
-      if ex.backtrace[0] !~ /^#{Regexp.escape from}:/
-        ex.backtrace[1] =~ /([^\s]+:\d+):/
+      if ex.backtrace[0] !~ /^#{Regexp.escape from}/
+        ex.backtrace[1] =~ /([^\s]+:\d+)/
         assert_equal from, $1
       end
     else
-      ex.backtrace[0] =~ /([^\s]+:\d+):/
+      ex.backtrace[0] =~ /([^\s]+:\d+)/
       assert_equal from, $1
     end
   end


### PR DESCRIPTION
Rails 4 has introduced a new way of code extraction for browser error
reporting (https://github.com/rails/rails/blob/fe12e4650802d8f28136660fc9ce62c6a28f19e1/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb#L59).

If a syntax error occurred in template, we should prepend to the
backtrace template's filename and line.

Without it, we'll get an useless 500 error with `We're sorry but something went wrong` message.

With fix:
![2014-08-03 13 44 53](https://cloud.githubusercontent.com/assets/4391269/3790239/e1fd628e-1af2-11e4-94a0-a0dc5657f86a.png)

Also, extend syntax error tests to the introduced case.
