### PR TITLE
fix Rails 4.2/5 test compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,10 @@ matrix:
   exclude:
     - rvm: rbx-2
       env: "TASK=test:rails RAILS=master"
+    - rvm: 1.9.3
+      env: "TASK=test:rails RAILS=master"
+    - rvm: 2.0.0
+      env: "TASK=test:rails RAILS=master"
   allow_failures:
     - env: "TASK=test:core_and_plugins TILT=master"
     - env: "TASK=test:rails RAILS=master"

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,9 @@ if ENV['TILT']
 end
 
 if ENV['RAILS']
+  # we need some smarter test logic for the different Rails versions
+  gem 'nokogiri'
+  
   if ENV['RAILS'] == 'master'
     gem 'rails', github: 'rails/rails'
   else
@@ -24,7 +27,7 @@ if ENV['RAILS']
 end
 
 #Choose minitest 4.7.x for sinatra or rails 3 and 4.0 otherwise go for newer version
-if ENV['SINATRA'] || (ENV['RAILS'] && !ENV['RAILS'].match(/4\.([1-9])(\..*)?/))
+if ENV['SINATRA'] || (ENV['RAILS'] && ENV['RAILS'].match(/^(3|4\.0)/))
   gem 'minitest', '~> 4.7.4'
 else
   gem 'minitest', '~> 5.1'

--- a/test/rails/test/helper.rb
+++ b/test/rails/test/helper.rb
@@ -3,5 +3,29 @@ ENV["RAILS_ENV"] = "test"
 
 require File.expand_path("../../config/environment.rb", __FILE__)
 require "rails/test_help"
+require "nokogiri"
 
 Rails.backtrace_cleaner.remove_silencers!
+
+class ActionDispatch::IntegrationTest
+
+protected
+
+  def assert_xpath(xpath, message="Unable to find '#{xpath}' in response body.")
+    assert_response :success, "Response type is not :success (code 200..299)."
+    
+    body = @response.body
+    assert !body.empty?, "No response body found."
+
+    doc = Nokogiri::HTML(body) rescue nil
+    assert_not_nil doc, "Cannot parse response body."
+
+    assert doc.xpath(xpath).size >= 1, message
+  end
+
+  def assert_html(expected, options = {})
+    expected = "<!DOCTYPE html><html><head><title>Dummy</title></head><body>#{options[:heading]}<div class=\"content\">#{expected}</div></body></html>" unless options[:skip_layout]
+    assert_equal expected, @response.body
+  end
+
+end

--- a/test/rails/test/test_slim.rb
+++ b/test/rails/test/test_slim.rb
@@ -2,7 +2,7 @@ require File.expand_path('../helper', __FILE__)
 
 class TestSlim < ActionDispatch::IntegrationTest
   test "normal view" do
-    get "slim/normal"
+    get "/slim/normal"
     assert_response :success
     assert_template "slim/normal"
     assert_template "layouts/application"
@@ -10,7 +10,7 @@ class TestSlim < ActionDispatch::IntegrationTest
   end
 
   test "xml view" do
-    get "slim/xml"
+    get "/slim/xml"
     assert_response :success
     assert_template "slim/xml"
     assert_template "layouts/application"
@@ -18,7 +18,7 @@ class TestSlim < ActionDispatch::IntegrationTest
   end
 
   test "helper" do
-    get "slim/helper"
+    get "/slim/helper"
     assert_response :success
     assert_template "slim/helper"
     assert_template "layouts/application"
@@ -26,61 +26,54 @@ class TestSlim < ActionDispatch::IntegrationTest
   end
 
   test "normal erb view" do
-    get "slim/erb"
+    get "/slim/erb"
     assert_html "<h1>Hello Erb!</h1>"
   end
 
   test "view without a layout" do
-    get "slim/no_layout"
+    get "/slim/no_layout"
     assert_template "slim/no_layout"
     assert_html "<h1>Hello Slim without a layout!</h1>", skip_layout: true
   end
 
   test "view with variables" do
-    get "slim/variables"
+    get "/slim/variables"
     assert_html "<h1>Hello Slim with variables!</h1>"
   end
 
   test "partial view" do
-    get "slim/partial"
+    get "/slim/partial"
     assert_html "<h1>Hello Slim!</h1><p>With a partial!</p>"
   end
 
   puts 'Streaming test enabled'
   test "streaming" do
-    get "slim/streaming"
+    get "/slim/streaming"
     output = "2f\r\n<!DOCTYPE html><html><head><title>Dummy</title>\r\nd\r\n</head><body>\r\n17\r\nHeading set from a view\r\n15\r\n<div class=\"content\">\r\n53\r\n<p>Page content</p><h1><p>Hello Streaming!</p></h1><h2><p>Hello Streaming!</p></h2>\r\n14\r\n</div></body></html>\r\n0\r\n\r\n"
     assert_equal output, @response.body
   end
 
   test "render integers" do
-    get "slim/integers"
+    get "/slim/integers"
     assert_html "<p>1337</p>"
   end
 
   test "render thread_options" do
-    get "slim/thread_options", attr: 'role'
+    get "/slim/thread_options", attr: 'role'
     assert_html '<p role="empty">Test</p>'
-    get "slim/thread_options", attr: 'id' # Overwriting doesn't work because of caching
+    get "/slim/thread_options", attr: 'id' # Overwriting doesn't work because of caching
     assert_html '<p role="empty">Test</p>'
   end
 
   test "content_for" do
-    get "slim/content_for"
+    get "/slim/content_for"
     assert_html "<p>Page content</p><h1><p>Hello Slim!</p></h1><h2><p>Hello Slim!</p></h2>", heading: 'Heading set from a view'
   end
 
   test "form_for" do
-    get "entries/edit/1"
+    get "/entries/edit/1"
     assert_match %r{action="/entries"}, @response.body
     assert_match %r{<label><b>Name</b></label>}, @response.body
-    assert_match %r{<input id="entry_name" name="entry\[name\]"}, @response.body
-  end
-
-  protected
-
-  def assert_html(expected, options = {})
-    expected = "<!DOCTYPE html><html><head><title>Dummy</title></head><body>#{options[:heading]}<div class=\"content\">#{expected}</div></body></html>" unless options[:skip_layout]
-    assert_equal expected, @response.body
+    assert_xpath '//input[@id="entry_name" and @name="entry[name]" and @type="text"]'
   end
 end


### PR DESCRIPTION
Hi,

I fixed some of the broken Rails tests:
- `ActionDispatch::Integration::RequestHelpers#get` and friends require a path to start with "/"
- The order of HTML attributes has changed when using form helpers, which caused the test to look ugly. To accommodate this, an `assert_xpath` helper is introduced (cf. `test/rails/test/helper.rb`).
- as rails/master now points to 5.0.0:
  - exclude 1.9/2.0 + rails-master from build matrix (Rails 5 will require Ruby >= 2.1)
  - simplify conditional in Gemfile

Some tests are still broken:
- jRuby closes streams an script tag (see [here](https://travis-ci.org/dmke/slim/jobs/45027520#L174-L191)). I just don't know where to start here...
- Rubinius fails to install (which seems to be an issue with Travis?)
