### PR TITLE
Added links to Omniref docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ A short list of the features...
 * Bugs:   <http://github.com/slim-template/slim/issues>
 * List:   <http://groups.google.com/group/slim-template>
 * API documentation:
-    * Latest Gem: <http://rubydoc.info/gems/slim/frames>
-    * GitHub master: <http://rubydoc.info/github/slim-template/slim/master/frames>
+    * Latest Gem: <http://rubydoc.info/gems/slim/frames> <https://www.omniref.com/ruby/gems/slim>
+    * GitHub master: <http://rubydoc.info/github/slim-template/slim/master/frames> <https://www.omniref.com/github/slim-template/slim>
 
 ## Introduction
 


### PR DESCRIPTION
Added links to Omniref Slim docs for current gem and GitHub master branch.