### PR TITLE
"--require" option introduced as a full version of "-r" shortcut

### DIFF
--- a/README.jp.md
+++ b/README.jp.md
@@ -1038,7 +1038,7 @@ Usage: slimrb [options]
     -c, --compile                    Compile only but do not run
     -e, --erb                        Convert to ERB
         --rails                      Generate rails compatible code (Implies --compile)
-    -r library                       Load library or plugin with -r slim/plugin
+    -r, --require library            Load library or plugin with -r slim/plugin
     -p, --pretty                     Produce pretty html
     -o, --option name=code           Set slim option
     -l, --locals Hash|YAML|JSON      Set local variables

--- a/README.md
+++ b/README.md
@@ -1038,7 +1038,7 @@ Usage: slimrb [options]
     -c, --compile                    Compile only but do not run
     -e, --erb                        Convert to ERB
         --rails                      Generate rails compatible code (Implies --compile)
-    -r library                       Load library or plugin with -r slim/plugin
+    -r, --require library            Load library or plugin with -r slim/plugin
     -p, --pretty                     Produce pretty html
     -o, --option name=code           Set slim option
     -l, --locals Hash|YAML|JSON      Set local variables

--- a/lib/slim/command.rb
+++ b/lib/slim/command.rb
@@ -44,7 +44,7 @@ module Slim
         @options[:compile] = true
       end
 
-      opts.on('-r library', "Load library or plugin with -r slim/plugin") do |lib|
+      opts.on('-r', '--require library', "Load library or plugin with -r slim/plugin") do |lib|
         require lib.strip
       end
 

--- a/test/core/test_commands.rb
+++ b/test/core/test_commands.rb
@@ -103,7 +103,7 @@ class TestSlimCommands < Minitest::Test
 
   def test_require
     with_tempfile 'puts "Not in slim"', 'rb' do |lib|
-      prepare_common_test STATIC_TEMPLATE, '-r', lib, stdin_file: false, file_file: false do |out, err|
+      prepare_common_test STATIC_TEMPLATE, '--require', lib, stdin_file: false, file_file: false do |out, err|
         assert err.empty?
         assert_equal "Not in slim\n<p>Hello World!</p>\n", out
       end


### PR DESCRIPTION
Hello, there. 

This is small PR which introduces full version of "-r" option for slimrb. The problem here is that some third party deployment tools does not provide an easy way to set shortcutted options to slimrb. So I think it would be more consistent to provide full version as well as shortcut.