### PR TITLE
#635 Sass Include Paths

### DIFF
--- a/lib/slim/embedded.rb
+++ b/lib/slim/embedded.rb
@@ -151,6 +151,7 @@ module Slim
       protected
 
       def tilt_render(tilt_engine, tilt_options, text)
+        tilt_options[:load_paths] = [ File.join(Rails.root, 'app', 'assets', 'stylesheets') ] if defined?(Rails)
         text = tilt_engine.new(tilt_options.merge(
           style: options[:pretty] ? :expanded : :compressed,
           cache: false)) { text }.render


### PR DESCRIPTION
There's probably a more-flexible/less-specific way to do this.
But, for the case of **Rails > Slim > Sass**, this will fix `@import` (https://github.com/slim-template/slim/issues/635).