### PR TITLE
Add development dependency

### DIFF
--- a/slim.gemspec
+++ b/slim.gemspec
@@ -23,4 +23,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('tilt', ['>= 1.3.3', '< 2.1'])
   s.add_development_dependency('yard')
   s.add_development_dependency('redcarpet')
+  s.add_development_dependency('sinatra')
+  s.add_development_dependency('rack-test')
 end

--- a/slim.gemspec
+++ b/slim.gemspec
@@ -21,4 +21,6 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('temple', ['~> 0.7.6'])
   s.add_runtime_dependency('tilt', ['>= 1.3.3', '< 2.1'])
+  s.add_development_dependency('yard')
+  s.add_development_dependency('redcarpet')
 end


### PR DESCRIPTION
I can not execute `rake yard` and `rake test:sinatra` .
The reason is `require 'bundler/setup'` reads Gemfile.lock dependency.
