### PR TITLE
Add missing requires to parser.rb and embedded.rb

### DIFF
--- a/lib/slim/embedded.rb
+++ b/lib/slim/embedded.rb
@@ -1,3 +1,5 @@
+require 'slim/filter'
+
 module Slim
   # @api private
   class TextCollector < Filter

--- a/lib/slim/parser.rb
+++ b/lib/slim/parser.rb
@@ -1,4 +1,6 @@
 # coding: utf-8
+require 'slim/embedded'
+
 module Slim
   # Parses Slim code and transforms it to a Temple expression
   # @api private


### PR DESCRIPTION
I was trying to use only the `slim/parser` (while working on #642) and some dependencies were missing.