### PR TITLE
Add additional attrs to shortcut

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+2015-09-04
+
+  * Add additional attributes feature to shortcuts
+
 3.0.6 (2015-06-05)
 
   * Fix warnings #625

--- a/README.md
+++ b/README.md
@@ -647,7 +647,7 @@ which renders to
 <div class="person" role="admin">Daniel</div>
 ~~~
 
-You can also set multiple attributes at once using one shortcut.
+You can also set multiple attributes with same value at once using one shortcut.
 
 ~~~ ruby
 Slim::Engine.set_options shortcut: {'@' => {attr: %w(data-role role)}}
@@ -663,6 +663,29 @@ which renders to
 
 ~~~ html
 <div class="person" role="admin" data-role="admin">Daniel</div>
+~~~
+
+You can also set additional fixed value attributes to a shortcut.
+
+~~~ ruby
+Slim::Engine.set_options shortcut: {'^' => {tag: 'script', attr: 'data-binding',
+  additional_attrs: { type: "text/javascript" }}}
+~~~
+
+Then
+
+~~~ slim
+^products
+  == @products.to_json
+~~~
+
+which renders to
+
+~~~ html
+<script data-binding="products" type="text/javascript">
+[{"name": "product1", "price": "$100"},
+ {"name": "prodcut2", "price": "$200"}]
+</script>
 ~~~
 
 #### ID shortcut `#` and class shortcut `.`

--- a/lib/slim/parser.rb
+++ b/lib/slim/parser.rb
@@ -55,18 +55,18 @@ module Slim
         @tab_re = "\t"
         @tab = ' '
       end
-      @tag_shortcut, @attr_shortcut, @attr_additional = {}, {}, {}
+      @tag_shortcut, @attr_shortcut, @additional_attrs = {}, {}, {}
       options[:shortcut].each do |k,v|
-        raise ArgumentError, 'Shortcut requires :tag and/or :attr' unless (v[:attr] || v[:tag] || v[:attrs]) && (v.keys - [:attr, :tag, :attrs]).empty?
+        raise ArgumentError, 'Shortcut requires :tag and/or :attr' unless (v[:attr] || v[:tag]) && (v.keys - [:attr, :tag, :additional_attrs]).empty?
         @tag_shortcut[k] = v[:tag] || options[:default_tag]
-        if v.include?(:attr) || v.include?(:attrs)
+        if v.include?(:attr) || v.include?(:additional_attrs)
           raise ArgumentError, 'You can only use special characters for attribute shortcuts' if k =~ /(\p{Word}|-)/
         end
         if v.include?(:attr)
           @attr_shortcut[k] = [v[:attr]].flatten
         end
-        if v.include?(:attrs)
-          @attr_additional[k] = v[:attrs]
+        if v.include?(:additional_attrs)
+          @additional_attrs[k] = v[:additional_attrs]
         end
       end
       keys = Regexp.union @attr_shortcut.keys.sort_by {|k| -k.size }
@@ -331,7 +331,7 @@ module Slim
         # because we don't want text interpolation in .class or #id shortcut
         syntax_error!('Illegal shortcut') unless shortcut = @attr_shortcut[$1]
         shortcut.each {|a| attributes << [:html, :attr, a, [:static, $2]] }
-        if additional_attr_pairs = @attr_additional[$1]
+        if additional_attr_pairs = @additional_attrs[$1]
           additional_attr_pairs.each do |k,v|
             attributes << [:html, :attr, k.to_s, [:static, v]]
           end

--- a/test/core/test_html_structure.rb
+++ b/test/core/test_html_structure.rb
@@ -7,7 +7,7 @@ class TestSlimHtmlStructure < TestSlim
 html
   head
     title Simple Test Title
-  body 
+  body
     p Hello World, meet Slim.
 }
 
@@ -97,6 +97,15 @@ h1#title This is my title
 }
 
     assert_html '<div class="hello world" id="notice" role="test">Hello World from @env</div><section role="abc">Hello World from @env</section>', source, shortcut: {'#' => {attr: 'id'}, '.' => {attr: 'class'}, '@' => {tag: 'section', attr: 'role'}}
+  end
+
+  def test_render_with_custom_shortcut_with_attrs
+    source = %q{
+^items
+  == "[{'title':'item0'},{'title':'item1'},{'title':'item2'},{'title':'item3'},{'title':'item4'}]"
+}
+    assert_html '<script data-binding="items" type="application/json">[{\'title\':\'item0\'},{\'title\':\'item1\'},{\'title\':\'item2\'},{\'title\':\'item3\'},{\'title\':\'item4\'}]</script>',
+                source, shortcut: {'^' => {tag: 'script', attr: 'data-binding', attrs: { type: "application/json" }}}
   end
 
   def test_render_with_text_block

--- a/test/core/test_html_structure.rb
+++ b/test/core/test_html_structure.rb
@@ -7,7 +7,7 @@ class TestSlimHtmlStructure < TestSlim
 html
   head
     title Simple Test Title
-  body
+  body 
     p Hello World, meet Slim.
 }
 

--- a/test/core/test_html_structure.rb
+++ b/test/core/test_html_structure.rb
@@ -99,13 +99,13 @@ h1#title This is my title
     assert_html '<div class="hello world" id="notice" role="test">Hello World from @env</div><section role="abc">Hello World from @env</section>', source, shortcut: {'#' => {attr: 'id'}, '.' => {attr: 'class'}, '@' => {tag: 'section', attr: 'role'}}
   end
 
-  def test_render_with_custom_shortcut_with_attrs
+  def test_render_with_custom_shortcut_and_additional_attrs
     source = %q{
 ^items
   == "[{'title':'item0'},{'title':'item1'},{'title':'item2'},{'title':'item3'},{'title':'item4'}]"
 }
     assert_html '<script data-binding="items" type="application/json">[{\'title\':\'item0\'},{\'title\':\'item1\'},{\'title\':\'item2\'},{\'title\':\'item3\'},{\'title\':\'item4\'}]</script>',
-                source, shortcut: {'^' => {tag: 'script', attr: 'data-binding', attrs: { type: "application/json" }}}
+                source, shortcut: {'^' => {tag: 'script', attr: 'data-binding', additional_attrs: { type: "application/json" }}}
   end
 
   def test_render_with_text_block

--- a/test/core/test_html_structure.rb
+++ b/test/core/test_html_structure.rb
@@ -99,6 +99,13 @@ h1#title This is my title
     assert_html '<div class="hello world" id="notice" role="test">Hello World from @env</div><section role="abc">Hello World from @env</section>', source, shortcut: {'#' => {attr: 'id'}, '.' => {attr: 'class'}, '@' => {tag: 'section', attr: 'role'}}
   end
 
+  def test_render_with_custom_array_shortcut
+    source = %q{
+#user@.admin Daniel
+}
+    assert_html '<div class="admin" id="user" role="admin">Daniel</div>', source, shortcut: {'#' => {attr: 'id'}, '.' => {attr: 'class'}, '@' => {attr: 'role'}, '@.' => {attr: ['class', 'role']}}
+  end
+
   def test_render_with_custom_shortcut_and_additional_attrs
     source = %q{
 ^items


### PR DESCRIPTION
This commit add additional attributes to shortcut.

Useful when output complicated tag with simplified shortcut
``` ruby
shortcut: {'^' => {tag: 'script', attr: 'data-binding', attrs: { type: "application/json" }}}
```
Then user input
``` slim
^items
  == "[{'title':'item0'},{'title':'item1'}]
```
will output
``` html
<script data-binding="items" type="application/json">[{'title':'item0'},{'title':'item1'}]</script>
```

Unit test added, too.