### PR TITLE
Add ability to ignore attribute shortcuts

### DIFF
--- a/test/core/test_html_structure.rb
+++ b/test/core/test_html_structure.rb
@@ -106,6 +106,13 @@ h1#title This is my title
     assert_html '<div class="admin" id="user" role="admin">Daniel</div>', source, shortcut: {'#' => {attr: 'id'}, '.' => {attr: 'class'}, '@' => {attr: 'role'}, '@.' => {attr: ['class', 'role']}}
   end
 
+  def test_render_with_ignored_shortcut
+    source = %q{
+#user@admin Daniel
+}
+    assert_html '<div id="user">Daniel</div>', source, shortcut: {'#' => {attr: 'id'}, '@' => {attr: false}}
+  end
+
   def test_render_with_custom_shortcut_and_additional_attrs
     source = %q{
 ^items

--- a/test/literate/TESTS.md
+++ b/test/literate/TESTS.md
@@ -1237,6 +1237,26 @@ renders as
 </div>
 ~~~
 
+#### Ignored attribute shortcuts
+
+Sometimes you need to disable rendering an attribute with a shortcut but still allow it to present in the template.
+
+~~~ options
+:shortcut => {'@' => {attr: false}, '#' => {attr: 'id'}}
+~~~
+
+~~~ slim
+#test@ignored
+#test
+~~~
+
+renders to
+
+~~~ html
+<div id="test"></div>
+<div id="test"></div>
+~~~
+
 ## Text interpolation
 
 Use standard Ruby interpolation. The text will be html escaped by default.


### PR DESCRIPTION
Long story short:

I want to render some extra attributes in one environment and do not want in another.

------------------

The full long story: 

I have two environments: test and production.
I have interactive tests which use custom selectors to find elements on the page.
I use `test_id` attribute to build selectors: 

```ruby
Slim::Engine.set_options shortcut: {'@' => {attr: 'test_id'}, '#' => {attr: 'id'}, '.' => {attr: 'class'}}
```

```slim
div@login_button
```

so I can use 

```
$('[test_id="login_button"]').click()
```

in my tests.

This way I just make it easier to select elements without touching any frontend-related stuff.

At the same time I don't want these attributes to appear on production since they are just for my test environment. 

So I want to disable them in the following way:

```ruby
if Rails.env.production?
  Slim::Engine.set_options shortcut: {'@' => {attr: false}, '#' => {attr: 'id'}, '.' => {attr: 'class'}}
else
  Slim::Engine.set_options shortcut: {'@' => {attr: 'qid'}, '#' => {attr: 'id'}, '.' => {attr: 'class'}}
end
```