### PR TITLE
Fixes typo in Output section

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ body
 
 ### Output `=`
 
-The equal sign tells Slim it's a Ruby call that produces output to add to the buffer. If your ruby code needs to use multiple lines, append a backslash `\` at the end of the lines, for example:
+The equals sign tells Slim it's a Ruby call that produces output to add to the buffer. If your ruby code needs to use multiple lines, append a backslash `\` at the end of the lines. For example:
 
 ~~~ slim
 = javascript_include_tag \


### PR DESCRIPTION
- Replaces equal sign with 

> equals sign

  It is more idiomatic. Although both forms exist, the accepted form seems to be “equals”.
  [wiki](https://en.wikipedia.org/wiki/Equals_sign)

- Tweaks grammar