### PR TITLE
Properly print out deprecation messages

### DIFF
--- a/lib/slim/parser.rb
+++ b/lib/slim/parser.rb
@@ -523,7 +523,7 @@ module Slim
       line = @orig_line.lstrip
       column = (@orig_line && @line ? @orig_line.size - @line.size : 0) + line.size - @orig_line.size
       warn %{Deprecated syntax: #{message}
-  #{options[:file]}, Line #{@lineno}, Column #{@column}
+  #{options[:file]}, Line #{@lineno}, Column #{column + 1}
     #{line}
     #{' ' * column}^
 }


### PR DESCRIPTION
`@column` in `Slim::Parser` is never assigned.
This commit make `#deprecated_syntax` to properly
print out where the column is.

For example:

```slim
p==' hello_world
```

prints

```
Deprecated syntax: =' for trailing whitespace is deprecated in favor of =>
  (__TEMPLATE__), Line 2, Column 4
    p=' hello_world
```