### PR TITLE
Default encoding of Ruby 2.0 or upper is UTF-8

### DIFF
--- a/lib/slim/parser.rb
+++ b/lib/slim/parser.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 module Slim
   # Parses Slim code and transforms it to a Temple expression
   # @api private

--- a/lib/slim/smart/parser.rb
+++ b/lib/slim/smart/parser.rb
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 module Slim
   module Smart
     # @api private

--- a/test/core/helper.rb
+++ b/test/core/helper.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 begin
   require 'codeclimate-test-reporter'
   CodeClimate::TestReporter.start

--- a/test/core/test_commands.rb
+++ b/test/core/test_commands.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 require 'helper'
 require 'open3'
 require 'tempfile'

--- a/test/core/test_unicode.rb
+++ b/test/core/test_unicode.rb
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 require 'helper'
 
 class TestSlimUnicode < TestSlim

--- a/test/smart/test_smart_text.rb
+++ b/test/smart/test_smart_text.rb
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 require 'helper'
 require 'slim/smart'
 


### PR DESCRIPTION
So we can omit magic comments.

ref: https://www.ruby-lang.org/en/news/2013/02/24/ruby-2-0-0-p0-is-released/