### PR TITLE
Remove whitespace when linebreaking quoted attributes. Closes #685

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,8 +463,8 @@ a href=="&amp;"
 You can break quoted attributes with backslash `\`
 
 ~~~ slim
-a data-title="help" data-content="extremely long help text that goes on\
-  and one and one and then starts over...."
+a data-title="help" data-content="extremely long help text that goes on \
+  and on and on and then starts over...."
 ~~~
 
 #### Ruby attributes

--- a/lib/slim/parser.rb
+++ b/lib/slim/parser.rb
@@ -491,7 +491,7 @@ module Slim
 
       until count == 0 && @line[0] == quote[0]
         if @line =~ /\A(\\)?\Z/
-          value << ($1 ? ' ' : "\n")
+          value << ($1 ? '' : "\n")
           expect_next_line
         else
           if @line[0] == ?{

--- a/test/literate/TESTS.md
+++ b/test/literate/TESTS.md
@@ -944,27 +944,27 @@ You can use newlines in quoted attributes
 
 ~~~ slim
 a data-title="help" data-content="extremely long help text that goes on
-  and one and one and then starts over...." Link
+  and on and on and then starts over...." Link
 ~~~
 
 renders as
 
 ~~~ html
 <a data-content="extremely long help text that goes on
-and one and one and then starts over...." data-title="help">Link</a>
+and on and on and then starts over...." data-title="help">Link</a>
 ~~~
 
 You can break quoted attributes with an backslash `\`
 
 ~~~ slim
-a data-title="help" data-content="extremely long help text that goes on\
-  and one and one and then starts over...." Link
+a data-title="help" data-content="extremely long help text that goes on \
+  and on and on and then starts over...." Link
 ~~~
 
 renders as
 
 ~~~ html
-<a data-content="extremely long help text that goes on and one and one and then starts over...." data-title="help">Link</a>
+<a data-content="extremely long help text that goes on and on and on and then starts over...." data-title="help">Link</a>
 ~~~
 
 #### Ruby attributes


### PR DESCRIPTION
I still may be missing a very good reason that this space exists, but there's been no mention of one on the issue (#685), and removing it doesn't _seem_ to break anything, so I figured I'd throw in a PR.

I also updated the readme to reflect that as a consequence of this change, if you really do want a space at the linebreak, it needs to be explicitly included (fixed a typo too).
