### PR TITLE
Fix README [ci-skip]

### DIFF
--- a/README.jp.md
+++ b/README.jp.md
@@ -1035,7 +1035,7 @@ html
 ### Rails
 
 Rails のジェネレータは [slim-rails](https://github.com/slim-template/slim-rails) によって提供されます。
-slim-rails は Rails で Slim を使用する場合に必須ではありません。Slim をインストールし Gemfile に `gem 'slim-rails'` を追加するだけです。
+slim-rails は Rails で Slim を使用する場合に必須ではありません。Slim をインストールし Gemfile に `gem 'slim'` を追加するだけです。
 後は .slim 拡張子を使えば Rails で使用できます。
 
 #### ストリーミング

--- a/README.md
+++ b/README.md
@@ -1035,7 +1035,7 @@ html
 ### Rails
 
 Rails generators are provided by [slim-rails](https://github.com/slim-template/slim-rails). slim-rails
-is not necessary to use Slim in Rails though. Just install Slim and add it to your Gemfile with `gem 'slim-rails'`.
+is not necessary to use Slim in Rails though. Just install Slim and add it to your Gemfile with `gem 'slim'`.
 Then just use the .slim extension and you're good to go.
 
 #### Streaming


### PR DESCRIPTION
If we don't need to use `slim-rails` to use `slim` with Rails, then we can only add `slim` to the gemfile, not `slim-rails`, right?