### PR TITLE
Relax Temple's dependency to allow v0.8.0

### DIFF
--- a/slim.gemspec
+++ b/slim.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>=2.0.0'
 
-  s.add_runtime_dependency('temple', ['~> 0.7.6'])
+  s.add_runtime_dependency('temple', ['>= 0.7.6', '< 0.9'])
   s.add_runtime_dependency('tilt', ['>= 1.3.3', '< 2.1'])
 end


### PR DESCRIPTION
v0.8.0's change https://github.com/judofyr/temple/pull/107 isn't related to Slim. So we can allow Temple 0.8.x. I need this to benchmark Slim against Haml 5.