### PR TITLE
Allow use of `@` symbol in class names

### DIFF
--- a/lib/slim/parser.rb
+++ b/lib/slim/parser.rb
@@ -70,7 +70,7 @@ module Slim
         end
       end
       keys = Regexp.union @attr_shortcut.keys.sort_by {|k| -k.size }
-      @attr_shortcut_re = /\A(#{keys}+)((?:\p{Word}|-)*)/
+      @attr_shortcut_re = /\A(#{keys}+)((?:\p{Word}|-|\\@)*)/
       keys = Regexp.union @tag_shortcut.keys.sort_by {|k| -k.size }
       @tag_re = /\A(?:#{keys}|\*(?=[^\s]+)|(\p{Word}(?:\p{Word}|:|-)*\p{Word}|\p{Word}+))/
       keys = Regexp.escape @code_attr_delims.keys.join
@@ -330,7 +330,7 @@ module Slim
         # The class/id attribute is :static instead of :slim :interpolate,
         # because we don't want text interpolation in .class or #id shortcut
         syntax_error!('Illegal shortcut') unless shortcut = @attr_shortcut[$1]
-        shortcut.each {|a| attributes << [:html, :attr, a, [:static, $2]] }
+        shortcut.each {|a| attributes << [:html, :attr, a, [:static, $2.delete('\\')]] }
         if additional_attr_pairs = @additional_attrs[$1]
           additional_attr_pairs.each do |k,v|
             attributes << [:html, :attr, k.to_s, [:static, v]]


### PR DESCRIPTION
`@` is a valid character for CSS class names. Slim does not parse this with the `.class` shorthand. This pull request allows for parsing of `\@` as `@` in a class name. For example, this line will now parse as expected:
```
.width-1-6\@s
```

Adding this small change will allow slim to use CSS frameworks like UIKit without falling back to the `div class="width-1-6@s"` syntax.

Another option would be to allow any character in a css class name that is preceded by a `\`. [Here](http://rubular.com/r/CC7HzGpqWO) is an example of this on Rubular.