### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ The doctype keyword can be used to generate the complex doctypes in a very simpl
 
 XML VERSION
 
-~~~~ slim
+~~~ slim
 doctype xml
   <?xml version="1.0" encoding="utf-8" ?>
 


### PR DESCRIPTION
Extra `~` in `~~~~` makes it unmatched with `~~~` so parser considers the rest of the file as a single slim block