### PR TITLE
Cross-site Scripting in splat attributes names

### DIFF
--- a/lib/slim/splat/builder.rb
+++ b/lib/slim/splat/builder.rb
@@ -1,7 +1,10 @@
 module Slim
+  class InvalidAttributeNameError < StandardError; end
   module Splat
     # @api private
     class Builder
+     # https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
+     INVALID_ATTRIBUTE_NAME_REGEX = /[ \0"'>\/=]/
       def initialize(options)
         @options = options
         @attrs = {}
@@ -25,15 +28,17 @@ module Slim
       end
 
       def attr(name, value)
-        attr_name = escape_html(true, name)
-        if @attrs[attr_name]
-          if delim = @options[:merge_attrs][attr_name]
-            @attrs[attr_name] += delim + value.to_s
+        if name =~ INVALID_ATTRIBUTE_NAME_REGEX
+          raise InvalidAttributeNameError, "Invalid attribute name '#{name}' was rendered"
+        end
+        if @attrs[name]
+          if delim = @options[:merge_attrs][name]
+            @attrs[name] += delim + value.to_s
           else
-            raise("Multiple #{attr_name} attributes specified")
+            raise("Multiple #{name} attributes specified")
           end
         else
-          @attrs[attr_name] = value
+          @attrs[name] = value
         end
       end
 

--- a/lib/slim/splat/builder.rb
+++ b/lib/slim/splat/builder.rb
@@ -25,14 +25,15 @@ module Slim
       end
 
       def attr(name, value)
-        if @attrs[name]
-          if delim = @options[:merge_attrs][name]
-            @attrs[name] += delim + value.to_s
+        attr_name = escape_html(true, name)
+        if @attrs[attr_name]
+          if delim = @options[:merge_attrs][attr_name]
+            @attrs[attr_name] += delim + value.to_s
           else
-            raise("Multiple #{name} attributes specified")
+            raise("Multiple #{attr_name} attributes specified")
           end
         else
-          @attrs[name] = value
+          @attrs[attr_name] = value
         end
       end
 

--- a/test/core/test_code_escaping.rb
+++ b/test/core/test_code_escaping.rb
@@ -71,7 +71,9 @@ p *{ "><script>alert(1)</script><p title" => 'test' }
 }
 
     with_html_safe do
-      assert_html "<p &gt;&lt;script&gt;alert(1)&lt;/script&gt;&lt;p title=\"test\"></p>", source, use_html_safe: true
+      assert_raises Slim::InvalidAttributeNameError do
+        render(source, use_html_safe: true)
+      end
     end
   end
 

--- a/test/core/test_code_escaping.rb
+++ b/test/core/test_code_escaping.rb
@@ -65,6 +65,16 @@ p *{ title: '&' }
     end
   end
 
+  def test_render_splat_injecting_evil_attr_name
+    source = %q{
+p *{ "><script>alert(1)</script><p title" => 'test' }
+}
+
+    with_html_safe do
+      assert_html "<p &gt;&lt;script&gt;alert(1)&lt;/script&gt;&lt;p title=\"test\"></p>", source, use_html_safe: true
+    end
+  end
+
 
   def test_render_attribute_with_html_safe_true
     source = %q{


### PR DESCRIPTION
Hello,

I was working on creating some new slim-related protection rules for [sqreen](https://www.sqreen.io/) when I think i found an issue in the current version.

Basically I managed to reproduce an issue that was originally [reported to Haml](https://github.com/haml/haml/issues/891).

Up until now it seems that the attribute names of a tag were not escaped. This can lead to an XSS when splat attributes of a tag are under user control (e.g. params). I reproduced that in my test rails app by doing a simple:
```
 p *params = some_var
```

Contrary to what was ultimately done in Haml and to limit code change, the current fix requests escaping on the attributes names (Haml raises on invalid attributes detected). I also added a new unit test for this.

Either way, thanks for the work on this gem!

PS: The tests on master are not passing at the moment on my computer (`TestSlimEmbeddedEngines#test_render_with_builder:
NameError: undefined local variable or method xml' for #<Env:..`)

