### PR TITLE
Prevent to generate invalid ruby code on embedded heredoc

### DIFF
--- a/lib/slim/embedded.rb
+++ b/lib/slim/embedded.rb
@@ -236,7 +236,7 @@ module Slim
     # Embeds ruby code
     class RubyEngine < Engine
       def on_slim_embedded(engine, body)
-        [:multi, [:newline], [:code, collect_text(body)]]
+        [:multi, [:newline], [:code, "#{collect_text(body)}\n"]]
       end
     end
 

--- a/test/core/test_embedded_engines.rb
+++ b/test/core/test_embedded_engines.rb
@@ -192,6 +192,17 @@ ruby:
     assert_html '3', source
   end
 
+  def test_render_with_ruby_heredoc
+    source = %q{
+ruby:
+  variable = <<-MSG
+  foobar
+  MSG
+= variable
+}
+    assert_html "foobar\n", source
+  end
+
   def test_render_with_scss
     source = %q{
 scss:

--- a/test/core/test_ruby_errors.rb
+++ b/test/core/test_ruby_errors.rb
@@ -119,7 +119,7 @@ ruby:
 = unknown_ruby_method
 }
 
-    assert_ruby_error NameError,"(__TEMPLATE__):6", source
+    assert_ruby_error NameError,"(__TEMPLATE__):7", source
   end
 
   def test_embedded_ruby2


### PR DESCRIPTION
Problem
======

Slim generates invalid ruby code if `ruby:` block has a heredoc at end.

For example:

```bash
$ cat test.slimo
ruby:
  v = <<-MSG
  foobar
  MSG
= v

$ slimrb test.slim
SyntaxError: test.slim:8: can't find string "MSG" anywhere before EOF
test.slim:2: syntax error, unexpected end-of-input, expecting tSTRING_CONTENT or tSTRING_DBEG or tSTRING_DVAR or tSTRING_END
; v = <<-MSG
            ^
  Use --trace for backtrace.
```

This cause is a semicolon after delimiter of heredoc(`MSG`).

```bash
$ slimrb -c test.slim
_buf = '';
; v = <<-MSG
foobar
MSG;
; _buf << ((::Temple::Utils.escape_html((v))).to_s);
; _buf
```

Heredoc delimiter does not allow putting a semicolon after the delimiter.
So, slim generates invalid ruby code from the example.

Solution
=====

Add a newline to embedded ruby code.

For example:

```ruby
$ slimrb test.slim
foobar

$ slimrb -c test.slim
_buf = '';
; v = <<-MSG
foobar
MSG
;
; _buf << ((::Temple::Utils.escape_html((v))).to_s);
; _buf
```