### PR TITLE
Explain how to avoid escaping interpolated content

### DIFF
--- a/README.md
+++ b/README.md
@@ -841,6 +841,13 @@ body
   h1 Welcome \#{current_user.name} to the show.
 ~~~
 
+To avoid escaping the interpolated content use double braces
+
+~~~ slim
+body
+  h1 Welcome #{{current_user.name}} to the show.
+~~~
+
 ## Embedded engines (Markdown, ...)
 
 Thanks to [Tilt](https://github.com/rtomayko/tilt), Slim has extensive support for embedding other template engines.

--- a/README.md
+++ b/README.md
@@ -826,7 +826,7 @@ fits your purposes. You should also be aware that most frameworks already bring 
 
 ## Text interpolation
 
-Use standard Ruby interpolation. The text will be html escaped by default.
+Use standard Ruby interpolation. The text will be html escaped by default, but you can avoid escaping by using double braces.
 
 ~~~ slim
 body
@@ -839,13 +839,6 @@ To escape the interpolation (i.e. render as is)
 ~~~ slim
 body
   h1 Welcome \#{current_user.name} to the show.
-~~~
-
-To avoid escaping the interpolated content use double braces
-
-~~~ slim
-body
-  h1 Welcome #{{current_user.name}} to the show.
 ~~~
 
 ## Embedded engines (Markdown, ...)


### PR DESCRIPTION
I found https://github.com/slim-template/slim/issues/102 when searching for this, but having it in the docs should make it easier for people to find.