### PR TITLE
Docs: add comments to regex

### DIFF
--- a/lib/slim/parser.rb
+++ b/lib/slim/parser.rb
@@ -72,7 +72,20 @@ module Slim
       keys = Regexp.union @attr_shortcut.keys.sort_by {|k| -k.size }
       @attr_shortcut_re = /\A(#{keys}+)((?:\p{Word}|-)*)/
       keys = Regexp.union @tag_shortcut.keys.sort_by {|k| -k.size }
-      @tag_re = /\A(?:#{keys}|\*(?=[^\s]+)|(\p{Word}(?:\p{Word}|:|-)*\p{Word}|\p{Word}+))/
+      @tag_re = /
+        \A                                    # at the start of the string ..
+        (?:                                   # a non-capturing group (for performance)
+          #{keys}                             # "shortcuts" defined above, like the "ID Shortcut"
+          |                                   # or
+          \*(?=[^\s]+)                        # "Dynamic tags" begin with an asterix
+          |                                   # or
+          (
+            \p{Word}(?:\p{Word}|:|-)*\p{Word} # a tag name containing colons or hyphens
+            |                                 # or
+            \p{Word}+                         # a plain, simple tag name
+          )
+        )
+      /x
       keys = Regexp.escape @code_attr_delims.keys.join
       @code_attr_delims_re = /\A[#{keys}]/
       keys = Regexp.escape @attr_list_delims.keys.join


### PR DESCRIPTION
Most regexes can be commented this way, using the `x` flag. This is called
"Free-Spacing Mode".

> Literal white space inside the pattern is ignored, and the octothorpe (#)
> character introduces a comment until the end of the line. This allows the
> components of the pattern to be organized in a potentially more readable
> fashion.
> http://ruby-doc.org/core-2.4.1/doc/regexp_rdoc.html#label-Free-Spacing+Mode+and+Comments

I think, for a parser that depends so heavily on regexes, comments like this
are very helpful.