### PR TITLE
Restrict access to public methods in logic_less templates

### DIFF
--- a/lib/slim/logic_less/context.rb
+++ b/lib/slim/logic_less/context.rb
@@ -63,7 +63,7 @@ module Slim
           @lookup.each do |lookup|
             case lookup
             when :method
-              return @dict.send(name, &block) if @dict.respond_to?(name)
+              return @dict.public_send(name, &block) if @dict.respond_to?(name, false)
             when :symbol
               return @dict[name].call(&block) if has_key?(name)
             when :string
@@ -80,7 +80,7 @@ module Slim
           @lookup.each do |lookup|
             case lookup
             when :method
-              return @dict.send(name) if @dict.respond_to?(name)
+              return @dict.public_send(name) if @dict.respond_to?(name, false)
             when :symbol
               return @dict[name] if has_key?(name)
             when :string

--- a/test/logic_less/test_logic_less.rb
+++ b/test/logic_less/test_logic_less.rb
@@ -116,6 +116,26 @@ p
     assert_html '<p><div class="name">Joe</div><div class="name">Jack</div></p>', source, scope: object, dictionary_access: :method
   end
 
+  def test_method_access_without_private
+    source = %q{
+p
+ - person
+  .age = age
+}
+
+    object = Object.new
+    def object.person
+      person = Object.new
+      def person.age
+        42
+      end
+      person.singleton_class.class_eval { private :age }
+      person
+    end
+
+    assert_html '<p><div class="age"></div></p>', source, scope: object, dictionary_access: :method
+  end
+
   def test_instance_variable_access
     source = %q{
 p


### PR DESCRIPTION
Because the `LogicLess::Context` object calls `send` for method access on its dictionary object, it means private methods are accessible.

It feels like the intention was that it's an object's *public* API that should be used for rendering.

This PR changes the method lookup to only query for public methods, and to call them using `public_send`