### PR TITLE
Improve performance parsing quoted attributes

### DIFF
--- a/benchmarks/view.erb
+++ b/benchmarks/view.erb
@@ -1,8 +1,10 @@
 <!DOCTYPE HTML>
 
-<html>
+<html lang="en">
   <head>
     <title>Simple Benchmark</title>
+    <meta charset="utf-8">
+    <meta name="description" content="This is an example of a meta description.">
   </head>
   <body>
     <h1><%= header %></h1>

--- a/benchmarks/view.haml
+++ b/benchmarks/view.haml
@@ -1,8 +1,10 @@
 !!! html
 
-%html
+%html{ lang: "en" }
   %head
     %title Simple Benchmark
+    %meta{ charset: "utf-8" }
+    %meta{ name: "description", content: "This is an example of a meta description." }
   %body
     %h1= header
     - unless item.empty?

--- a/benchmarks/view.slim
+++ b/benchmarks/view.slim
@@ -1,7 +1,9 @@
 doctype html
-html
+html lang="en"
   head
     title Simple Benchmark
+    meta charset="utf-8"
+    meta name="description" content="This is an example of a meta description."
   body
     h1 == header
     - unless item.empty?

--- a/lib/slim/parser.rb
+++ b/lib/slim/parser.rb
@@ -82,6 +82,10 @@ module Slim
       @attr_name = "\\A\\s*([^\0\s#{keys}]+)"
       @quoted_attr_re = /#{@attr_name}\s*=(=?)\s*("|')/
       @code_attr_re = /#{@attr_name}\s*=(=?)\s*/
+
+      splat_prefix = Regexp.escape(options[:splat_prefix])
+      splat_regexp_source = '\A\s*' << splat_prefix << '(?=[^\s]+)'
+      @splat_attrs_regexp = Regexp.new(splat_regexp_source)
     end
 
     # Compile string to Temple expression
@@ -413,10 +417,6 @@ module Slim
         boolean_attr_re = /#{@attr_name}(?=(\s|#{Regexp.escape delimiter}|\Z))/
         end_re = /\A\s*#{Regexp.escape delimiter}/
       end
-
-      splat_prefix        = Regexp.escape(options[:splat_prefix])
-      splat_regexp_source = '\A\s*' << splat_prefix << '(?=[^\s]+)'
-      @splat_attrs_regexp = Regexp.new(splat_regexp_source)
 
       while true
         case @line


### PR DESCRIPTION
Whilst benchmarking a Rails app with memory bloat issues, I noticed a small improvement which could be made to `Parser#parse_attributes`

Changes:
- Adds static quoted attributes to the `.slim` / `.haml` /  `.erb` benchmark templates.
- Moves creation of splat prefix regex to the `Parser` initialization, rather than each invocation of `Parser#parse_attributes`.

Local `benchdiff` results:

```
                    user     system      total        real
------------------------------------------------------Parse
After patch:    2.650000   0.010000   2.660000 (  2.660088)
Before patch:   2.930000   0.010000   2.940000 (  2.936652)
Improvement: 9%

-----------------------------------------------------Render
After patch:    0.840000   0.000000   0.840000 (  0.840143)
Before patch:   0.840000   0.000000   0.840000 (  0.838565)
Improvement: 0%
```