### PR TITLE
Set default tilt encoding to UTF-8

### DIFF
--- a/lib/slim/embedded.rb
+++ b/lib/slim/embedded.rb
@@ -134,6 +134,7 @@ module Slim
       def on_slim_embedded(engine, body)
         tilt_engine = Tilt[engine] || raise(Temple::FilterError, "Tilt engine #{engine} is not available.")
         tilt_options = options[engine.to_sym] || {}
+        tilt_options[:default_encoding] ||= 'utf-8'
         [:multi, tilt_render(tilt_engine, tilt_options, collect_text(body)), collect_newlines(body)]
       end
 


### PR DESCRIPTION
This fixes the "invalid byte sequence in US-ASCII" error in some environments where locale is not set.

Also see: https://github.com/dry-rb/dry-view/pull/5 and https://github.com/hanami/view/issues/76