### PR TITLE
fix warning in Slim::Command when using slimrb

### DIFF
--- a/lib/slim/command.rb
+++ b/lib/slim/command.rb
@@ -110,19 +110,19 @@ module Slim
           Template.new(@options[:file]) { @options[:input].read }.render(nil, locals)
         end
 
-      rescue Exception => ex
-        raise ex if @options[:trace] || SystemExit === ex
-        $stderr.print "#{ex.class}: " if ex.class != RuntimeError
-        $stderr.puts ex.message
-        $stderr.puts '  Use --trace for backtrace.'
-        exit 1
-      else
-        unless @options[:output]
-          file = args.shift
-          @options[:output] = file ? File.open(file, 'w') : $stdout
-        end
-        @options[:output].puts(result)
-        exit 0
+    rescue Exception => ex
+      raise ex if @options[:trace] || SystemExit === ex
+      $stderr.print "#{ex.class}: " if ex.class != RuntimeError
+      $stderr.puts ex.message
+      $stderr.puts '  Use --trace for backtrace.'
+      exit 1
+    else
+      unless @options[:output]
+        file = args.shift
+        @options[:output] = file ? File.open(file, 'w') : $stdout
+      end
+      @options[:output].puts(result)
+      exit 0
     end
   end
 end


### PR DESCRIPTION
As can be seen in #829 there are some warnings being generated by Slim::Command because of indentation. Just quickly fixing those. Cheers.