### PR TITLE
Fix tests breaking with tilt 2.0.10

### DIFF
--- a/test/literate/TESTS.md
+++ b/test/literate/TESTS.md
@@ -368,7 +368,7 @@ You don't need the explicit `\` if the line ends with a comma `,`.
 
 ~~~ slim
 ruby:
-  def test(*args)
+  def self.test(*args)
     args.join('-')
   end
 = test('arg1',
@@ -961,7 +961,7 @@ You don't need the explicit `\` if the line ends with a comma `,`.
 
 ~~~ slim
 ruby:
-  def test(*args)
+  def self.test(*args)
     args.join('-')
   end
 a href=test('arg1',
@@ -1073,7 +1073,7 @@ with the :tag key.
 
 ~~~ slim
 ruby:
-  def a_unless_current
+  def self.a_unless_current
     @page_current ? {tag: 'span'} : {tag: 'a', href: 'http://slim-lang.com/'}
   end
 - @page_current = true

--- a/test/rails/app/assets/config/manifest.js
+++ b/test/rails/app/assets/config/manifest.js
@@ -1,0 +1,1 @@
+// file required by sprockets >= 4.0


### PR DESCRIPTION
Hi,

Since upgrading to tilt 2.0.10 the test fail with the following error:

```
  1) Error:
Slim test suite::HTML tags::Attributes::Ruby attributes#test_0002_should render:
ArgumentError: unknown command 'a'
    (__TEMPLATE__):6:in `test'
    (__TEMPLATE__):6:in `__tilt_47336302970300'
    /tmp/slim/vendor/bundle/ruby/2.5.0/gems/tilt-2.0.10/lib/tilt/template.rb:170:in `call'
    /tmp/slim/vendor/bundle/ruby/2.5.0/gems/tilt-2.0.10/lib/tilt/template.rb:170:in `evaluate'
    /tmp/slim/vendor/bundle/ruby/2.5.0/gems/tilt-2.0.10/lib/tilt/template.rb:109:in `render'
    /tmp/slim/test/literate/helper.rb:13:in `render'
    (eval):436:in `block (6 levels) in <class:LiterateTest>'

  2) Error:
Slim test suite::HTML tags::Attributes::Dynamic tags `*`#test_0001_should render:
NameError: undefined local variable or method `a_unless_current' for #<#<Class:0x0000561aafb97510>:0x0000561aafe192c0>
    (__TEMPLATE__):7:in `__tilt_47336302970300'
    /tmp/slim/vendor/bundle/ruby/2.5.0/gems/tilt-2.0.10/lib/tilt/template.rb:170:in `call'
    /tmp/slim/vendor/bundle/ruby/2.5.0/gems/tilt-2.0.10/lib/tilt/template.rb:170:in `evaluate'
    /tmp/slim/vendor/bundle/ruby/2.5.0/gems/tilt-2.0.10/lib/tilt/template.rb:109:in `render'
    /tmp/slim/test/literate/helper.rb:13:in `render'
    (eval):492:in `block (6 levels) in <class:LiterateTest>'

  3) Error:
Slim test suite::Line indicators::Output `=`#test_0004_should render:
ArgumentError: unknown command 'a'
    (__TEMPLATE__):6:in `test'
    (__TEMPLATE__):6:in `__tilt_47336302970300'
    /tmp/slim/vendor/bundle/ruby/2.5.0/gems/tilt-2.0.10/lib/tilt/template.rb:170:in `call'
    /tmp/slim/vendor/bundle/ruby/2.5.0/gems/tilt-2.0.10/lib/tilt/template.rb:170:in `evaluate'
    /tmp/slim/vendor/bundle/ruby/2.5.0/gems/tilt-2.0.10/lib/tilt/template.rb:109:in `render'
    /tmp/slim/test/literate/helper.rb:13:in `render'
    (eval):149:in `block (5 levels) in <class:LiterateTest>'
```

This issue is explained in https://github.com/rtomayko/tilt/pull/347 and a workaround is provided there too.
This PR implements that proposed workaround.

Thanks,
Joseph