### PR TITLE
Add support for slashes w/ digits and colons in class / id names

### DIFF
--- a/lib/slim/parser.rb
+++ b/lib/slim/parser.rb
@@ -70,7 +70,7 @@ module Slim
         end
       end
       keys = Regexp.union @attr_shortcut.keys.sort_by {|k| -k.size }
-      @attr_shortcut_re = /\A(#{keys}+)((?:\p{Word}|-)*)/
+      @attr_shortcut_re = /\A(#{keys}+)((?:\p{Word}|-|\/\d+|:(\w|-)+)*)/
       keys = Regexp.union @tag_shortcut.keys.sort_by {|k| -k.size }
       @tag_re = /\A(?:#{keys}|\*(?=[^\s]+)|(\p{Word}(?:\p{Word}|:|-)*\p{Word}|\p{Word}+))/
       keys = Regexp.escape @code_attr_delims.keys.join

--- a/test/literate/TESTS.md
+++ b/test/literate/TESTS.md
@@ -1186,13 +1186,15 @@ renders to
 
 #### ID shortcut and class shortcut `.`
 
-ID and class shortcuts can contain dashes.
+ID and class shortcuts can contain dashes, slashes with digits, and colons.
 
 ~~~ slim
 .-test text
 #test- text
 .--a#b- text
 .a--test-123#--b text
+.a-1/2#b-1/2 text
+.ab:c-test#d:e text
 ~~~
 
 renders as
@@ -1208,6 +1210,12 @@ renders as
   text
 </div>
 <div class="a--test-123" id="--b">
+  text
+</div>
+<div class="a-1/2" id="b-1/2">
+  text
+</div>
+<div class="ab:c-test" id="d:e">
   text
 </div>
 ~~~


### PR DESCRIPTION
This is to add support for [Tailwind CSS](https://tailwindcss.com/), which uses classnames that use dashes and colons, like `w-1/2` and `md:w-4`.

Here's an example from their site, with an added `w-1/2` class on the wrapping div:

```slim
.md:flex.w-1/2
  .md:flex-shrink-0
    img.rounded-lg.md:w-56(
      src="https://images.unsplash.com/photo-1556740738-b6a63e27c4df?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=448&q=80"
      alt="Woman paying for a purchase")

  .mt-4.md:mt-0.md:ml-6
    .uppercase.tracking-wide.text-sm.text-indigo-600.font-bold
      | Marketing
    a.block.mt-1.text-lg.leading-tight.font-semibold.text-gray-900.hover:underline
      | Finding customers for your new business
    p.mt-2.text-gray-600
      | Getting a new business off the ground is a lot of hard work. Here are five ideas you can use to find your first customers.
```

```html
<div class="md:flex w-1/2">
  <div class="md:flex-shrink-0">
    <img alt="Woman paying for a purchase" class="rounded-lg md:w-56" src="https://images.unsplash.com/photo-1556740738-b6a63e27c4df?ixlib=rb-1.2.1&amp;ixid=eyJhcHBfaWQiOjEyMDd9&amp;auto=format&amp;fit=crop&amp;w=448&amp;q=80">
  </div>
  <div class="mt-4 md:mt-0 md:ml-6">
    <div class="uppercase tracking-wide text-sm text-indigo-600 font-bold">Marketing</div>
    <a class="block mt-1 text-lg leading-tight font-semibold text-gray-900 hover:underline">Finding customers for your new business</a>
    <p class="mt-2 text-gray-600">Getting a new business off the ground is a lot of hard work. Here are five ideas you can use to find your first customers.</p>
  </div>
</div>
```

More Examples:

- [Responsive Design](https://tailwindcss.com/docs/responsive-design)
- [Width](https://tailwindcss.com/docs/width)