### PR TITLE
Fix build for Rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,8 @@ if ENV['RAILS']
   else
     gem 'rails', "= #{ENV['RAILS']}"
   end
+
+  gem 'slim-rails', require: false
 end
 
 #Choose minitest 4.7.x for sinatra < 1.4.6 or rails 3 and 4.0 otherwise go for newer version

--- a/test/rails/config/application.rb
+++ b/test/rails/config/application.rb
@@ -5,9 +5,10 @@ require 'action_controller/railtie'
 require 'action_view/railtie'
 #require 'active_record/railtie'
 #require 'action_mailer/railtie'
-require "sprockets/railtie"
+require 'sprockets/railtie'
 
 require 'slim'
+require 'slim-rails/register_engine'
 
 module Dummy
   class Application < Rails::Application
@@ -48,7 +49,7 @@ module Dummy
       config.assets.configure do |env|
         if env.respond_to?(:register_transformer) && Sprockets::VERSION.to_i > 3
           env.register_mime_type 'text/slim', extensions: ['.slim', '.slim.html']
-          env.register_transformer 'text/slim', 'text/html', RegisterEngine::Transformer
+          env.register_transformer 'text/slim', 'text/html', Slim::Rails::RegisterEngine::Transformer
         elsif env.respond_to?(:register_engine)
           args = ['.slim', Slim::Template]
           args << { silence_deprecation: true } if Sprockets::VERSION.start_with?('3')


### PR DESCRIPTION
Looking at the build pipeline, the build stopped failing without any changes to the code that would indicate a problem.

The only thing that I could discern was that a dependency must have gotten an update causing the failure.

After doing some digging, I saw that `Sprockets` had gotten a major release to `4.0.0`.

The configuration in `test/rails/config/application.rb`, the source of the build failure, checks to see if the `Sprockets` version is > 3.

If so, it triggers  some code that was also used in [`slim-rails`](https://github.com/slim-template/slim-rails/blob/b19741ba76a09a3badd0c5145dea6b087064fb87/lib/slim-rails/register_engine.rb#L31-L39), per [this commit from a couple years ago](https://github.com/slim-template/slim/commit/14a845a75047fd564acdc940c25f9bab599bbb9c).

The code works fine in `slim-rails` because `RegisterEngine` [lives in `slim-rails`](https://github.com/slim-template/slim-rails/blob/b19741ba76a09a3badd0c5145dea6b087064fb87/lib/slim-rails/register_engine.rb#L1), but unfortunately does not exist in the core `slim` project, causing the `NameError`.

I suppose this was missed because until recently `Sprockets` was < 4.0 and the code written a couple years back never needed to run.

To fix this, I added the `slim-rails` gem to the `Gemfile`, and included the missing `RegisterEngine` module.