### PR TITLE
CI: Run tests against JRuby latest release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
   - 2.6.1
   - 2.5.3
   - 2.4.5
-  - jruby-9.2.6.0
+  - jruby-9.2.11.1
   - jruby-9.1.17.0
 
 # Recommend sudo required when using trusty dist
@@ -34,5 +34,5 @@ matrix:
   exclude:
     - rvm: 2.4.5
       env: "TASK=test:rails RAILS=6.0.0.beta2"
-    - rvm: jruby-9.1.17.0
+    - rvm: jruby-9.2.11.1
       env: "TASK=test:rails RAILS=6.0.0.beta2"


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.11.1**.

[JRuby 9.2.11.1 release blog post](https://www.jruby.org/2020/03/25/jruby-9-2-11-1.html)