### PR TITLE
CI: Use Rails 6.0.3 for Rails 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ dist: trusty
 
 script: "bundle exec rake $TASK"
 
-# "Warning: the --client flag is deprecated and has no effect most JVMs
+# Avoid "Warning: the --client flag is deprecated and has no effect most JVMs"
 before_install:
   - unset _JAVA_OPTIONS
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ env:
   global:
     - secure: "a7sD9iwPJJn3Fj+mn62GAmy/PEguh3elrilsp1KS+WfDiCiIKD8Q5KG2Jv67DGcQAGI3dPWeh7+ZhZ/W7nEipwWUBmSvGYVeoF63y8j6mNRLeekqspj94l47hXyFePj9bCadY1b1/xY4lE1pMEU8eA8AOUHUqCSuH+Kk/MuvyLM="
     - JAVA_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xms60M -Xmx720M -XX:InitialCodeCacheSize=40M -XX:ReservedCodeCacheSize=120M"
+    - JRUBY_OPTS: "-Xcext.enabled=true --debug"
   matrix:
     - "TASK=test:core_and_plugins"
     - "TASK=test:rails RAILS=6.0.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
     - secure: "a7sD9iwPJJn3Fj+mn62GAmy/PEguh3elrilsp1KS+WfDiCiIKD8Q5KG2Jv67DGcQAGI3dPWeh7+ZhZ/W7nEipwWUBmSvGYVeoF63y8j6mNRLeekqspj94l47hXyFePj9bCadY1b1/xY4lE1pMEU8eA8AOUHUqCSuH+Kk/MuvyLM="
   matrix:
     - "TASK=test:core_and_plugins"
-    - "TASK=test:rails RAILS=6.0.0.beta2"
+    - "TASK=test:rails RAILS=6.0.3"
     - "TASK=test:rails RAILS=5.2.2"
     - "TASK=test:rails RAILS=5.2.1.1"
     - "TASK=test:rails RAILS=5.2.1"
@@ -33,6 +33,6 @@ env:
 matrix:
   exclude:
     - rvm: 2.4.5
-      env: "TASK=test:rails RAILS=6.0.0.beta2"
+      env: "TASK=test:rails RAILS=6.0.3"
     - rvm: jruby-9.2.11.1
-      env: "TASK=test:rails RAILS=6.0.0.beta2"
+      env: "TASK=test:rails RAILS=6.0.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,17 @@ dist: trusty
 
 script: "bundle exec rake $TASK"
 
+# "Warning: the --client flag is deprecated and has no effect most JVMs
+before_install:
+  - unset _JAVA_OPTIONS
+
 after_success:
   - bundle exec codeclimate-test-reporter
 
 env:
   global:
     - secure: "a7sD9iwPJJn3Fj+mn62GAmy/PEguh3elrilsp1KS+WfDiCiIKD8Q5KG2Jv67DGcQAGI3dPWeh7+ZhZ/W7nEipwWUBmSvGYVeoF63y8j6mNRLeekqspj94l47hXyFePj9bCadY1b1/xY4lE1pMEU8eA8AOUHUqCSuH+Kk/MuvyLM="
+    - JAVA_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xms60M -Xmx720M -XX:InitialCodeCacheSize=40M -XX:ReservedCodeCacheSize=120M"
   matrix:
     - "TASK=test:core_and_plugins"
     - "TASK=test:rails RAILS=6.0.3"
@@ -33,6 +38,8 @@ env:
 matrix:
   exclude:
     - rvm: 2.4.5
+      env: "TASK=test:rails RAILS=6.0.3"
+    - rvm: jruby-9.1.17.0
       env: "TASK=test:rails RAILS=6.0.3"
     - rvm: jruby-9.2.11.1
       env: "TASK=test:rails RAILS=6.0.3"


### PR DESCRIPTION
This PR stops using a beta of Rails 6, preferring the **latest release of Rails 6**.

- Add JRuby 9.2.11.1 (latest release)
- Configure Java options to not be in the way of the test suite (output tests etc) - the CI configuration code [was borrowed from jruby/jruby](https://github.com/jruby/jruby/blob/master/.travis.yml)