### PR TITLE
resolve load order dependencies with Rails

### DIFF
--- a/lib/slim.rb
+++ b/lib/slim.rb
@@ -12,3 +12,4 @@ require 'slim/code_attributes'
 require 'slim/engine'
 require 'slim/template'
 require 'slim/version'
+require 'slim/railtie' if defined?(Rails::Railtie)

--- a/lib/slim/railtie.rb
+++ b/lib/slim/railtie.rb
@@ -1,0 +1,17 @@
+module Slim
+  class Railtie < Rails::Railtie
+    initializer "initialize slim template handler" do
+      ActiveSupport.on_load(:action_view) do
+        Slim::RailsTemplate = Temple::Templates::Rails(Slim::Engine,
+                                                       register_as: :slim,
+                                                       # Use rails-specific generator. This is necessary
+                                                       # to support block capturing and streaming.
+                                                       generator: Temple::Generators::RailsOutputBuffer,
+                                                       # Disable the internal slim capturing.
+                                                       # Rails takes care of the capturing by itself.
+                                                       disable_capture: true,
+                                                       streaming: true)
+      end
+    end
+  end
+end

--- a/lib/slim/template.rb
+++ b/lib/slim/template.rb
@@ -2,18 +2,4 @@ module Slim
   # Tilt template implementation for Slim
   # @api public
   Template = Temple::Templates::Tilt(Slim::Engine, register_as: :slim)
-
-  if defined?(::ActionView)
-    # Rails template implementation for Slim
-    # @api public
-    RailsTemplate = Temple::Templates::Rails(Slim::Engine,
-                                             register_as: :slim,
-                                             # Use rails-specific generator. This is necessary
-                                             # to support block capturing and streaming.
-                                             generator: Temple::Generators::RailsOutputBuffer,
-                                             # Disable the internal slim capturing.
-                                             # Rails takes care of the capturing by itself.
-                                             disable_capture: true,
-                                             streaming: true)
-  end
 end


### PR DESCRIPTION
**Context:**

After removing some dependencies from our Gemfile (specifically `sprockets-rails`) we started to see missing template errors in our Sidekiq workers (delivering emails). We use `sidekiqswarm` to start workers. I traced the issue back to the slim initialization code for Rails. The issue was that `sidekiqswarm` will load gems before booting the rails application (Runs `Bundler.require(*groups)` before requiring `config/application.rb`). In that scenario, slim will not register it's Rails template handler as `ActionView` is not yet defined.

**Patch:**

Using `if defined?(::ActionView)` can cause complications in
environments where Bundler gems are preloaded before a Rails
application boots. This will lead to a scenario where Slim just
silently fails to register a Rails template handler, which will lead
to missing template errors later.

The patch uses a `Rails::Railtie` instead to define a lazy
initialization path using an `on_load` hook. This will make the slim
gem independent of the gem and rails app loading order. The only
constraint is that `gem rails` appears before `gem slim` in the
Gemfile. However, this applies for pretty much any Rails gem.