### PR TITLE
Add option to hyphenate underscore attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -976,7 +976,8 @@ There are a lot of them but the good thing is, that Slim checks the configuratio
 | Symbol | :format | :xhtml | HTML output format (Possible formats :html, :xhtml, :xml) |
 | String | :attr_quote | '"' | Character to wrap attributes in html (can be ' or ") |
 | Hash | :merge_attrs | \{'class' => ' '} | Joining character used if multiple html attributes are supplied (e.g. class="class1 class2") |
-| Array&lt;String&gt; | :hyphen_attrs | %w(data) | Attributes which will be hyphenated if a Hash is given (e.g. data={a:1,b:2} will render as data-a="1" data-b="2") |
+| Array&lt;String&gt; | :hyphen_attrs | %w(data) | Attributes which will be hyphenated if a Hash is given (e.g. data={a_foo:1,b:2} will render as data-a_foo="1" data-b="2") |
+| Boolean | :hyphen_underscore_attrs | false | Attributes that have underscores in their names will be hyphenated (e.g. data={a_foo:1,b_bar:2} will render as data-a-foo="1" data-b-bar="2") |
 | Boolean | :sort_attrs | true | Sort attributes by name |
 | Symbol | :js_wrapper | nil | Wrap javascript by :comment, :cdata or :both. You can also :guess the wrapper based on :format. |
 | Boolean | :pretty | false | Pretty HTML indenting, only block level tags are indented <b>(This is slower!)</b> |

--- a/lib/slim/splat/builder.rb
+++ b/lib/slim/splat/builder.rb
@@ -90,8 +90,14 @@ module Slim
 
       def hyphen_attr(name, escape, value)
         if Hash === value
-          value.each do |n, v|
-            hyphen_attr("#{name}-#{n}", escape, v)
+          if @options[:hyphen_underscore_attrs] 
+            value.each do |n, v|
+              hyphen_attr("#{name}-#{n.to_s.gsub('_', '-')}", escape, v)
+            end
+          else
+            value.each do |n, v|
+              hyphen_attr("#{name}-#{n}", escape, v)
+            end
           end
         else
           attr(name, escape_html(value != true && escape, value))

--- a/lib/slim/splat/filter.rb
+++ b/lib/slim/splat/filter.rb
@@ -3,7 +3,8 @@ module Slim
     # @api private
     class Filter < ::Slim::Filter
       define_options :merge_attrs, :attr_quote, :sort_attrs, :default_tag, :format, :disable_capture,
-                     hyphen_attrs: %w(data aria), use_html_safe: ''.respond_to?(:html_safe?)
+                     hyphen_attrs: %w(data aria), use_html_safe: ''.respond_to?(:html_safe?),
+                     hyphen_underscore_attrs: false
 
       def call(exp)
         @splat_options = nil

--- a/test/core/test_html_attributes.rb
+++ b/test/core/test_html_attributes.rb
@@ -116,6 +116,14 @@ option(selected class="clazz") Text
     assert_html '<div class="alpha" data-a="alpha" data-b="beta" data-c-e="epsilon" data-c_d="gamma"></div>', source
   end
 
+  def test_hyphenated_underscore_attribute
+    source = %{
+.alpha data={a: 'alpha', b: 'beta', c_d: 'gamma', c: {e: 'epsilon'}}
+}
+
+    assert_html '<div class="alpha" data-a="alpha" data-b="beta" data-c-d="gamma" data-c-e="epsilon"></div>', source, hyphen_underscore_attrs: true 
+  end
+
   def test_splat_without_content
     source = %q{
 *hash


### PR DESCRIPTION
This adds an option to disable the change introduced in #807. It also partially addresses the need of #820, though it hyphenates all underscore-named attributes as before #807.

**edit** 
Note that I've put the condition around the loop instead of inside it as there may be a slight performance gain if it isn't checked for every attribute.