### PR TITLE
Allow splat parsing to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,7 +559,7 @@ This renders as:
 div class="first second third"
 ~~~
 
-Splat attributes prefix may be configured via `splat_prefix` option. Default value is `'*'`
+Splat attributes prefix may be configured via `splat_prefix` option. Default value is `'*'`. `nil` disables splat attributes.
 
 #### Dynamic tags `*`
 

--- a/lib/slim/parser.rb
+++ b/lib/slim/parser.rb
@@ -83,9 +83,14 @@ module Slim
       @quoted_attr_re = /#{@attr_name}\s*=(=?)\s*("|')/
       @code_attr_re = /#{@attr_name}\s*=(=?)\s*/
 
-      splat_prefix = Regexp.escape(options[:splat_prefix])
-      splat_regexp_source = '\A\s*' << splat_prefix << '(?=[^\s]+)'
-      @splat_attrs_regexp = Regexp.new(splat_regexp_source)
+      @splat_attrs_regexp =
+        if options[:splat_prefix]
+          splat_prefix = Regexp.escape(options[:splat_prefix])
+          splat_regexp_source = '\A\s*' << splat_prefix << '(?=[^\s]+)'
+          Regexp.new(splat_regexp_source)
+        else
+          false
+        end
     end
 
     # Compile string to Temple expression

--- a/test/core/test_splat_prefix_option.rb
+++ b/test/core/test_splat_prefix_option.rb
@@ -152,4 +152,10 @@ h1 data-id="123" #{prefix}hash This is my title
     end
   end
 
+  def test_disabled_splat
+    source =%Q{
+h1 data-id="123" *hash This is my title
+}
+    assert_html '<h1 data-id="123">*hash This is my title</h1>', source, options(nil)
+  end
 end


### PR DESCRIPTION
I have a use case were we'd like to use slim but we don't want the splat functionality.  Would you consider allowing it to be disabled?