### PR TITLE
Enable bundler caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 # https://www.ruby-lang.org/en/downloads/releases/
 language: ruby
+cache: bundler
 rvm:
   - 2.7.2
   - 2.6.6


### PR DESCRIPTION
Would be interested to know why bundler cache hasn't been enabled for Travis. Thank you.