### PR TITLE
Update rails head build to reference main instead of master

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,8 +31,8 @@ end
 
 if ENV['RAILS']
   # we need some smarter test logic for the different Rails versions
-  if ENV['RAILS'] == 'master'
-    gem 'rails', :github => 'rails/rails'
+  if ENV['RAILS'] == 'main'
+    gem 'rails', :github => 'rails/rails', branch: 'main'
   else
     gem 'rails', "= #{ENV['RAILS']}"
   end


### PR DESCRIPTION
Rails default branch is now main the build should reflect that

adding the branch prevents the error,

```
Git error: command `git rev-parse --verify master` in directory /Users/hparker/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/cache/bundler/git/rails-fcf0202857b07db1a0f6220dae5ca99319ca0f32 has failed.
Revision master does not exist in the repository https://github.com/rails/rails.git. Maybe you misspelled it?
If this error persists you could try removing the cache directory '/Users/hparker/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/cache/bundler/git/rails-fcf0202857b07db1a0f6220dae5ca99319ca0f32'
```

which can happen your first time running this build.