### PR TITLE
Add support for 'case/in'

### DIFF
--- a/lib/slim/do_inserter.rb
+++ b/lib/slim/do_inserter.rb
@@ -7,7 +7,7 @@ module Slim
   #
   # @api private
   class DoInserter < Filter
-    BLOCK_REGEX = /(\A(if|unless|else|elsif|when|begin|rescue|ensure|case)\b)|\bdo\s*(\|[^\|]*\|\s*)?\Z/
+    BLOCK_REGEX = /(\A(if|unless|else|elsif|when|in|begin|rescue|ensure|case)\b)|\bdo\s*(\|[^\|]*\|\s*)?\Z/
 
     # Handle control expression `[:slim, :control, code, content]`
     #

--- a/lib/slim/end_inserter.rb
+++ b/lib/slim/end_inserter.rb
@@ -10,8 +10,8 @@ module Slim
   #
   # @api private
   class EndInserter < Filter
-    IF_RE = /\A(if|begin|unless|else|elsif|when|rescue|ensure)\b|\bdo\s*(\|[^\|]*\|)?\s*$/
-    ELSE_RE = /\A(else|elsif|when|rescue|ensure)\b/
+    IF_RE = /\A(if|begin|unless|else|elsif|when|in|rescue|ensure)\b|\bdo\s*(\|[^\|]*\|)?\s*$/
+    ELSE_RE = /\A(else|elsif|when|in|rescue|ensure)\b/
     END_RE = /\Aend\b/
 
     # Handle multi expression `[:multi, *exps]`

--- a/test/core/test_code_structure.rb
+++ b/test/core/test_code_structure.rb
@@ -120,6 +120,23 @@ p
     assert_html '<p>42 is the answer</p><p>41 is the answer</p><p>42 is the answer</p><p>41 is the answer</p>', source
   end
 
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7")
+    def test_render_with_case_in
+      source = %q{
+  p
+    - case [:greet, "world"]
+    - in :greet, value if false
+      = "Goodbye #{value}"
+    - in :greet, value unless true
+      = "Top of the morning to you, #{value}"
+    - in :greet, value
+      = "Hello #{value}"
+  }
+
+      assert_html '<p>Hello world</p>', source
+    end
+  end
+
   def test_render_with_slim_comments
     source = %q{
 p Hello


### PR DESCRIPTION
Only supported in Ruby 2.7+, and .travis.yml also runs tests in 2.6, so exclude the test in unsupported Rubies.

We just looked for "when" and added "in" alongside it – seems to work as expected.