### PR TITLE
Chomp sass output only if not frozen (compatibility with sass-embedded gem)

### DIFF
--- a/lib/slim/embedded.rb
+++ b/lib/slim/embedded.rb
@@ -155,7 +155,7 @@ module Slim
         text = tilt_engine.new(tilt_options.merge(
           style: options[:pretty] ? :expanded : :compressed,
           cache: false)) { text }.render
-        text = text.chomp
+        text = text.chomp unless text.frozen?
         [:static, text]
       end
     end


### PR DESCRIPTION
I'm the author of the [sass-embedded](https://github.com/ntkme/sass-embedded-host-ruby) gem, and I have been working on integrating it with other gems to replace the deprecated sassc gem.

[The tilt integration for sass-embedded](https://github.com/rtomayko/tilt/pull/367) has been merged and I found an issue when testing with slim:

```
/usr/local/bundle/gems/slim-4.1.0/lib/slim/embedded.rb:158:in `chomp!': can't modify frozen String: ".sass {\n  margin: 0;\n}" (FrozenError)
        from /usr/local/bundle/gems/slim-4.1.0/lib/slim/embedded.rb:158:in `tilt_render'
        from /usr/local/bundle/gems/slim-4.1.0/lib/slim/embedded.rb:138:in `on_slim_embedded'
        from /usr/local/bundle/gems/slim-4.1.0/lib/slim/embedded.rb:203:in `on_slim_embedded'
        from /usr/local/bundle/gems/slim-4.1.0/lib/slim/embedded.rb:103:in `on_slim_embedded'
```

The problem is that sass-embedded returns a frozen string, and slim tries to chomp it.

Since sass-embedded (dart-sass) does not add a newline at the end of output like sassc, there is no need to chomp the output. Thus, this PR changes it to conditionally chomp the output only if it is not frozen.  