### PR TITLE
Add missing require 'ostruct' in a test

### DIFF
--- a/test/core/test_code_evaluation.rb
+++ b/test/core/test_code_evaluation.rb
@@ -163,6 +163,7 @@ p id=(1 + 1)*5 Test it
   end
 
   def test_code_attribute_does_not_modify_argument
+    require 'ostruct'
     template = 'span class=attribute'
     model = OpenStruct.new(attribute: [:a, :b, [:c, :d]])
     output = Slim::Template.new { template }.render(model)


### PR DESCRIPTION
`OpenStruct` is not a core library but just a default gem, so it needs to be `require`d. This test file is currently failing on newer Rubies, e.g. Ruby 2.5+.