### PR TITLE
Support temple 0.9.1+

### DIFF
--- a/slim.gemspec
+++ b/slim.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>=2.0.0'
 
-  s.add_runtime_dependency('temple', ['>= 0.7.6', '< 0.9'])
+  s.add_runtime_dependency('temple', ['>= 0.7.6', '!= 0.9.0'])
   s.add_runtime_dependency('tilt', ['>= 2.0.6', '< 2.1'])
 end

--- a/test/core/test_commands.rb
+++ b/test/core/test_commands.rb
@@ -58,7 +58,11 @@ class TestSlimCommands < Minitest::Test
     prepare_common_test DYNAMIC_TEMPLATE, '--rails' do |out, err|
       assert err.empty?
 
-      assert out.include? %Q{@output_buffer = ActiveSupport::SafeBuffer.new;}
+      if Gem::Version.new(Temple::VERSION) >= Gem::Version.new('0.9')
+        assert out.include? %Q{@output_buffer = output_buffer || ActionView::OutputBuffer.new;}
+      else
+        assert out.include? %Q{@output_buffer = ActiveSupport::SafeBuffer.new;}
+      end
       assert out.include? %Q{@output_buffer.safe_concat(("<p>Hello "#{STRING_FREEZER}));}
       assert out.include? %Q{@output_buffer.safe_concat(((::Temple::Utils.escape_html((name))).to_s));}
       assert out.include? %Q{@output_buffer.safe_concat(("!</p>"#{STRING_FREEZER}));}


### PR DESCRIPTION
temple 0.9.0 has had an issue on Slim https://github.com/judofyr/temple/issues/137, but I fixed it in temple 0.9.1.

I feel users should have the option to bump the version as they wish, so I didn't leave `< 0.10`. However, because 0.9.0 is known to have a bug that impacts Slim, I specifically excluded 0.9.0 for convenience.