### PR TITLE
Lambda shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,6 +692,30 @@ which renders to
 </script>
 ~~~
 
+#### Lambda shortcuts
+
+You can define custom shortcuts using lambdas.
+
+In this example we add `~` to create a shortcut with a special processing (adding a prefix) for the class attribute.
+
+~~~ ruby
+Slim::Engine.set_options shortcut: {'~' => {attr: ->(v) {["class", "\"styled-#{v}\""]}}}
+~~~
+
+We can use it in Slim code like this
+
+~~~ slim
+h1~title Hello
+~text~question How are you?
+~~~
+
+which renders to
+
+~~~ html
+<h1 class="styled-title">Hello</h1>
+<div class="styled-text styled-question">How are you?</div>
+~~~
+
 #### ID shortcut `#` and class shortcut `.`
 
 You can specify the `id` and `class` attributes in the following shortcut form

--- a/README.md
+++ b/README.md
@@ -699,21 +699,21 @@ You can define custom shortcuts using lambdas.
 In this example we add `~` to create a shortcut with a special processing (adding a prefix) for the class attribute.
 
 ~~~ ruby
-Slim::Engine.set_options shortcut: {'~' => {attr: ->(v) {["class", "\"styled-#{v}\""]}}}
+Slim::Engine.set_options shortcut: {'~' => {attr: ->(v) {{class: "styled-#{v}"}}}}
 ~~~
 
 We can use it in Slim code like this
 
 ~~~ slim
 h1~title Hello
-~text~question How are you?
+~text~question.paragraph How are you?
 ~~~
 
 which renders to
 
 ~~~ html
 <h1 class="styled-title">Hello</h1>
-<div class="styled-text styled-question">How are you?</div>
+<div class="styled-text styled-question paragraph">How are you?</div>
 ~~~
 
 #### ID shortcut `#` and class shortcut `.`

--- a/lib/slim/parser.rb
+++ b/lib/slim/parser.rb
@@ -338,11 +338,10 @@ module Slim
         syntax_error!('Illegal shortcut') unless shortcut = @attr_shortcut[$1]
 
         if shortcut.is_a?(Proc)
-          value = shortcut.call($2)
-          attributes << [:html, :attr, value[0], [:dynamic, value[1]]]
+          values = shortcut.call($2)
+          values.each {|a, v| attributes << [:html, :attr, a, [:static, v]] }
         else
-          value = [:static, $2]
-          shortcut.each {|a| attributes << [:html, :attr, a, value] }
+          shortcut.each {|a| attributes << [:html, :attr, a, [:static, $2]] }
         end
 
         if additional_attr_pairs = @additional_attrs[$1]

--- a/lib/slim/parser.rb
+++ b/lib/slim/parser.rb
@@ -55,21 +55,22 @@ module Slim
         @tab_re = "\t"
         @tab = ' '
       end
-      @tag_shortcut, @attr_shortcut, @additional_attrs, @attr_value = {}, {}, {}, {}
+      @tag_shortcut, @attr_shortcut, @additional_attrs = {}, {}, {}
       options[:shortcut].each do |k,v|
-        raise ArgumentError, 'Shortcut requires :tag and/or :attr' unless (v[:attr] || v[:tag]) && (v.keys - [:attr, :tag, :additional_attrs, :attr_value]).empty?
+        raise ArgumentError, 'Shortcut requires :tag and/or :attr' unless (v[:attr] || v[:tag]) && (v.keys - [:attr, :tag, :additional_attrs]).empty?
         @tag_shortcut[k] = v[:tag] || options[:default_tag]
         if v.include?(:attr) || v.include?(:additional_attrs)
           raise ArgumentError, 'You can only use special characters for attribute shortcuts' if k =~ /(\p{Word}|-)/
         end
         if v.include?(:attr)
-          @attr_shortcut[k] = [v[:attr]].flatten
+          if v[:attr].is_a?(Proc)
+            @attr_shortcut[k] = v[:attr]
+          else
+            @attr_shortcut[k] = [v[:attr]].flatten
+          end
         end
         if v.include?(:additional_attrs)
           @additional_attrs[k] = v[:additional_attrs]
-        end
-        if v.include?(:attr_value)
-          @attr_value[k] = v[:attr_value]
         end
       end
       keys = Regexp.union @attr_shortcut.keys.sort_by {|k| -k.size }
@@ -336,13 +337,14 @@ module Slim
         # because we don't want text interpolation in .class or #id shortcut
         syntax_error!('Illegal shortcut') unless shortcut = @attr_shortcut[$1]
 
-        if @attr_value[$1]
-          value = [:dynamic, @attr_value[$1].call($2)]
+        if shortcut.is_a?(Proc)
+          value = shortcut.call($2)
+          attributes << [:html, :attr, value[0], [:dynamic, value[1]]]
         else
           value = [:static, $2]
+          shortcut.each {|a| attributes << [:html, :attr, a, value] }
         end
 
-        shortcut.each {|a| attributes << [:html, :attr, a, value] }
         if additional_attr_pairs = @additional_attrs[$1]
           additional_attr_pairs.each do |k,v|
             attributes << [:html, :attr, k.to_s, [:static, v]]

--- a/test/core/test_html_structure.rb
+++ b/test/core/test_html_structure.rb
@@ -120,7 +120,7 @@ h1#title This is my title
 ~foo Hello
 }
     assert_html '<div class="styled-foo">Hello</div>',
-                source, shortcut: {'~' => {attr: ->(v) {["class", "\"styled-#{v}\""]}}}
+                source, shortcut: {'~' => {attr: ->(v) {{class: "styled-#{v}"}}}}
   end
 
   def test_render_with_custom_lambda_shortcut_and_multiple_values
@@ -128,16 +128,24 @@ h1#title This is my title
 ~foo~bar Hello
 }
     assert_html '<div class="styled-foo styled-bar">Hello</div>',
-                source, shortcut: {'~' => {attr: ->(v) {["class", "\"styled-#{v}\""]}}}
+                source, shortcut: {'~' => {attr: ->(v) {{class: "styled-#{v}"}}}}
   end
 
-#   def test_render_with_custom_lambda_shortcut_and_existing_class
-#     source = %q{
-# ~foo.baz Hello
-# }
-#     assert_html '<div class="styled-foo baz">Hello</div>',
-#                 source, shortcut: {'~' => {attr: ->(v) {["class", "\"styled-#{v}\""]}}}
-#   end
+  def test_render_with_custom_lambda_shortcut_and_existing_class
+    source = %q{
+~foo.baz Hello
+}
+    assert_html '<div class="styled-foo baz">Hello</div>',
+                source, shortcut: {'~' => {attr: ->(v) {{class: "styled-#{v}"}}}, '.' => {attr: 'class'}}
+  end
+
+  def test_render_with_existing_class_and_custom_lambda_shortcut
+    source = %q{
+.baz~foo Hello
+}
+    assert_html '<div class="baz styled-foo">Hello</div>',
+                source, shortcut: {'~' => {attr: ->(v) {{class: "styled-#{v}"}}}, '.' => {attr: 'class'}}
+  end
 
   def test_render_with_text_block
     source = %q{

--- a/test/core/test_html_structure.rb
+++ b/test/core/test_html_structure.rb
@@ -116,35 +116,35 @@ h1#title This is my title
   end
 
   def test_render_with_custom_lambda_shortcut
+    Slim::Parser.options[:shortcut].update({'~' => {attr: ->(v) {{class: "styled-#{v}"}}}})
     source = %q{
 ~foo Hello
 }
-    assert_html '<div class="styled-foo">Hello</div>',
-                source, shortcut: {'~' => {attr: ->(v) {{class: "styled-#{v}"}}}}
+    assert_html '<div class="styled-foo">Hello</div>', source
   end
 
   def test_render_with_custom_lambda_shortcut_and_multiple_values
+    Slim::Parser.options[:shortcut].update({'~' => {attr: ->(v) {{class: "styled-#{v}"}}}})
     source = %q{
 ~foo~bar Hello
 }
-    assert_html '<div class="styled-foo styled-bar">Hello</div>',
-                source, shortcut: {'~' => {attr: ->(v) {{class: "styled-#{v}"}}}}
+    assert_html '<div class="styled-foo styled-bar">Hello</div>', source
   end
 
   def test_render_with_custom_lambda_shortcut_and_existing_class
+    Slim::Parser.options[:shortcut].update({'~' => {attr: ->(v) {{class: "styled-#{v}"}}}})
     source = %q{
 ~foo.baz Hello
 }
-    assert_html '<div class="styled-foo baz">Hello</div>',
-                source, shortcut: {'~' => {attr: ->(v) {{class: "styled-#{v}"}}}, '.' => {attr: 'class'}}
+    assert_html '<div class="styled-foo baz">Hello</div>', source
   end
 
   def test_render_with_existing_class_and_custom_lambda_shortcut
+    Slim::Parser.options[:shortcut].update({'~' => {attr: ->(v) {{class: "styled-#{v}"}}}})
     source = %q{
 .baz~foo Hello
 }
-    assert_html '<div class="baz styled-foo">Hello</div>',
-                source, shortcut: {'~' => {attr: ->(v) {{class: "styled-#{v}"}}}, '.' => {attr: 'class'}}
+    assert_html '<div class="baz styled-foo">Hello</div>', source
   end
 
   def test_render_with_text_block

--- a/test/core/test_html_structure.rb
+++ b/test/core/test_html_structure.rb
@@ -115,6 +115,30 @@ h1#title This is my title
                 source, shortcut: {'^' => {tag: 'script', attr: 'data-binding', additional_attrs: { type: "application/json" }}}
   end
 
+  def test_render_with_custom_lambda_shortcut
+    source = %q{
+~foo Hello
+}
+    assert_html '<div class="styled-foo">Hello</div>',
+                source, shortcut: {'~' => {attr: ->(v) {["class", "\"styled-#{v}\""]}}}
+  end
+
+  def test_render_with_custom_lambda_shortcut_and_multiple_values
+    source = %q{
+~foo~bar Hello
+}
+    assert_html '<div class="styled-foo styled-bar">Hello</div>',
+                source, shortcut: {'~' => {attr: ->(v) {["class", "\"styled-#{v}\""]}}}
+  end
+
+#   def test_render_with_custom_lambda_shortcut_and_existing_class
+#     source = %q{
+# ~foo.baz Hello
+# }
+#     assert_html '<div class="styled-foo baz">Hello</div>',
+#                 source, shortcut: {'~' => {attr: ->(v) {["class", "\"styled-#{v}\""]}}}
+#   end
+
   def test_render_with_text_block
     source = %q{
 p


### PR DESCRIPTION
This allows passing a lambda as `attr` param when defining a shortcut.

```rb
Slim::Parser.options[:shortcut].update({
  '~' => { attr: ->(v) { ["class", "\"styled-#{v}\""] } }
})
```

Then in your slim template you can do:

```slim
h1~title Hello
~text~question How are you?
```

which renders to:

```html
<h1 class="styled-title">Hello</h1>
<div class="styled-text styled-question">How are you?</div>
```

Related discussions
- https://github.com/slim-template/slim/issues/813#issuecomment-1400857486
- https://github.com/ViewComponent/view_component/pull/677#issuecomment-817023300