### PR TITLE
Fix Railtie load error

### DIFF
--- a/lib/slim/railtie.rb
+++ b/lib/slim/railtie.rb
@@ -1,5 +1,5 @@
 module Slim
-  class Railtie < Rails::Railtie
+  class Railtie < ::Rails::Railtie
     initializer "initialize slim template handler" do
       ActiveSupport.on_load(:action_view) do
         Slim::RailsTemplate = Temple::Templates::Rails(Slim::Engine,


### PR DESCRIPTION
This commit fixes an error when requiring `slim` via `slim-rails` (at least with Rails 7.0.4 and Slim 5.0 on my project :shrug:):

```
uninitialized constant Slim::Rails::Railtie (NameError)

  class Railtie < Rails::Railtie
```