### PR TITLE
Allow Slim to be used with Tilt 2.1.0

### DIFF
--- a/slim.gemspec
+++ b/slim.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.5.0'
 
   s.add_runtime_dependency('temple', ['~> 0.10.0'])
-  s.add_runtime_dependency('tilt', ['>= 2.0.6', '< 2.1'])
+  s.add_runtime_dependency('tilt', ['>= 2.0.6', '< 2.2'])
 end


### PR DESCRIPTION
It would be great to be able to use Slim with [Tilt 2.1.0](https://github.com/jeremyevans/tilt/blob/7907334d43afb53d37122470e5b346d235ad40c2/CHANGELOG.md#210-2023-02-17)

The Sinatra framework have tests using both Tilt and Slim, but when the tests installs Tilt 2.1.0, a very old version of Slim (0.6.1) is used (I assume because it does not have any requirement on the version of Tilt): https://github.com/sinatra/sinatra/issues/1884#issuecomment-1440401836