### PR TITLE
Do not swallow single quote after output line indicator

### DIFF
--- a/lib/slim/parser.rb
+++ b/lib/slim/parser.rb
@@ -230,10 +230,12 @@ module Slim
         # Found an output block.
         # We expect the line to be broken or the next line to be indented.
         @line = $'
+        leading_ws = $2.include?('<'.freeze)
+        trailing_ws = $2.include?('>'.freeze)
         block = [:multi]
-        @stacks.last << [:static, ' '] if $2.include?('<'.freeze)
+        @stacks.last << [:static, ' '] if leading_ws
         @stacks.last << [:slim, :output, $1.empty?, parse_broken_line, block]
-        @stacks.last << [:static, ' '] if $2.include?('>'.freeze)
+        @stacks.last << [:static, ' '] if trailing_ws
         @stacks << block
       when @embedded_re
         # Embedded template detected. It is treated as block.

--- a/lib/slim/parser.rb
+++ b/lib/slim/parser.rb
@@ -226,15 +226,14 @@ module Slim
         block = [:multi]
         @stacks.last << [:slim, :control, parse_broken_line, block]
         @stacks << block
-      when /\A=(=?)(['<>]*)/
+      when /\A=(=?)([<>]*)/
         # Found an output block.
         # We expect the line to be broken or the next line to be indented.
         @line = $'
-        trailing_ws = $2.include?('>'.freeze)
         block = [:multi]
         @stacks.last << [:static, ' '] if $2.include?('<'.freeze)
         @stacks.last << [:slim, :output, $1.empty?, parse_broken_line, block]
-        @stacks.last << [:static, ' '] if trailing_ws
+        @stacks.last << [:static, ' '] if $2.include?('>'.freeze)
         @stacks << block
       when @embedded_re
         # Embedded template detected. It is treated as block.


### PR DESCRIPTION
A single quote is currently allowed directly after the `output` line indicator together with the white space markers `<` and `>`.  This single quote is just swallowed without effect.

No test shows this example, and I guess it is a copy-and-paste error from another line indicator or something.

If there is no actual use case for this single quote, I propose we remove it.

Example:

```slim
=' 7x7
```

This outputs "49" today, and I propose it is a syntax error with "unterminated string meets end of file".