### PR TITLE
Allow whitespace markers for verbatim text: ´|<`, `|>`, and `|<>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,17 @@ You can also embed html in the text line
   | <tr><td>#{a.name}</td><td>#{a.description}</td></tr>
 ~~~
 
+#### Verbatim text with leading and/or treailing white space `|<` `|>` `|<>`
+
+You can add white space around verbatim text in the same as for `=`:
+~~~ slim
+| This line will not have any extra white space.
+|  This line will have a leading space, but it is difficult to see.
+|< This line will have a leading white space.
+|> This line will have a trailing white space.
+|<> This line will have both leading and trailing white space.
+~~~
+
 ### Verbatim text with trailing white space `'`
 
 The single quote tells Slim to copy the line (similar to `|`), but makes sure that a single trailing white space is appended.

--- a/lib/slim/parser.rb
+++ b/lib/slim/parser.rb
@@ -209,10 +209,12 @@ module Slim
       when /\A\//
         # Slim comment
         parse_comment_block
-      when /\A([\|'])( ?)/
+      when /\A([\|'])([<>]*)( ?)/
         # Found verbatim text block.
-        trailing_ws = $1 == "'"
-        @stacks.last << [:slim, :text, :verbatim, parse_text_block($', @indents.last + $2.size + 1)]
+        leading_ws = $2.include?('<'.freeze)
+        trailing_ws = ($1 == "'") || ($2.include?('>'.freeze))
+        @stacks.last << [:static, ' '] if leading_ws
+        @stacks.last << [:slim, :text, :verbatim, parse_text_block($', @indents.last + $3.size + 1)]
         @stacks.last << [:static, ' '] if trailing_ws
       when /\A</
         # Inline html

--- a/test/literate/TESTS.md
+++ b/test/literate/TESTS.md
@@ -27,6 +27,22 @@ renders as
 Text block
 ~~~
 
+You can add leading or trailing white space with the `<` and `>` markers:
+
+~~~ slim
+|< Text with leading whitespace.
+|  Text with leading whitespace.
+|> Text with trailing whitespace.
+|<> Text with both leading and trailing whitespace.
+~~~
+
+renders as
+
+~~~ html
+ Text with leading whitespace. Text with leading whitespace.Text with trailing whitespace.  Text with both leading and trailing whitespace. 
+~~~
+
+
 Multiple lines can be indented beneath the first text line.
 
 ~~~ slim


### PR DESCRIPTION
Fixes #882