### PR TITLE
Add regression test for capture handling in Rails

### DIFF
--- a/test/rails/app/views/slim/attributes.html.slim
+++ b/test/rails/app/views/slim/attributes.html.slim
@@ -1,0 +1,3 @@
+/ Exercises Temple `:capture` handling (used here for preparing HTML attributes) with the
+/ Rails-specific Temple generators
+.static class="#{class_names(dynamic: true, absent: false)}"

--- a/test/rails/app/views/slim/attributes.html.slim
+++ b/test/rails/app/views/slim/attributes.html.slim
@@ -1,3 +1,3 @@
 / Exercises Temple `:capture` handling (used here for preparing HTML attributes) with the
 / Rails-specific Temple generators
-.static class="#{class_names(dynamic: true, absent: false)}"
+.static class="#{['a', 'b'].join('-')}"

--- a/test/rails/test/test_slim.rb
+++ b/test/rails/test/test_slim.rb
@@ -79,7 +79,7 @@ class TestSlim < ActionDispatch::IntegrationTest
 
   test "attributes" do
     get "/slim/attributes"
-    assert_html "<div class=\"static dynamic\"></div>"
+    assert_html "<div class=\"static a-b\"></div>"
   end
 
   test "splat" do

--- a/test/rails/test/test_slim.rb
+++ b/test/rails/test/test_slim.rb
@@ -77,6 +77,11 @@ class TestSlim < ActionDispatch::IntegrationTest
     assert_xpath '//input[@id="entry_name" and @name="entry[name]" and @type="text"]'
   end
 
+  test "attributes" do
+    get "/slim/attributes"
+    assert_html "<div class=\"static dynamic\"></div>"
+  end
+
   test "splat" do
     get "/slim/splat"
     assert_html "<div id=\"splat\"><splat>Hello</splat></div>"


### PR DESCRIPTION
As discussed with @minad in https://github.com/judofyr/temple/pull/112#issuecomment-1506839532, here is a simple regression test intended to catch any issues around the specific intersection of Temple's capture handling and Slim's Rails-specific Temple generator.

Locally, I've tested this against:

- `gem 'temple', :github => 'judofyr/temple'`
- `gem "temple", github: "timriley/temple", branch: "propagate-options-to-capture-generator"` (matching this PR: https://github.com/judofyr/temple/pull/144)

And the test passes in both cases.

The goal of adding this test now is to build sufficient confidence before introducing this change to propagate options to nested capture_generators in Temple (https://github.com/judofyr/temple/pull/144).

@minad — this is my first contribution to Slim. Please let me know if you'd like to see anything different here.