### PR TITLE
Reduce object allocations by using sort_by! where it is safe

### DIFF
--- a/lib/slim/parser.rb
+++ b/lib/slim/parser.rb
@@ -70,9 +70,9 @@ module Slim
           @additional_attrs[k] = v[:additional_attrs]
         end
       end
-      keys = Regexp.union @attr_shortcut.keys.sort_by {|k| -k.size }
+      keys = Regexp.union @attr_shortcut.keys.sort_by! { |k| -k.size }
       @attr_shortcut_re = /\A(#{keys}+)((?:\p{Word}|-|\/\d+|:(\w|-)+)*)/
-      keys = Regexp.union @tag_shortcut.keys.sort_by {|k| -k.size }
+      keys = Regexp.union @tag_shortcut.keys.sort_by! { |k| -k.size }
       @tag_re = /\A(?:#{keys}|\*(?=[^\s]+)|(\p{Word}(?:\p{Word}|:|-)*\p{Word}|\p{Word}+))/
       keys = Regexp.escape @code_attr_delims.keys.join
       @code_attr_delims_re = /\A[#{keys}]/

--- a/lib/slim/smart/parser.rb
+++ b/lib/slim/smart/parser.rb
@@ -8,9 +8,9 @@ module Slim
       def initialize(opts = {})
         super
         word_re = options[:implicit_text] ? '[_a-z0-9]' : '\p{Word}'
-        attr_keys = Regexp.union(@attr_shortcut.keys.sort_by {|k| -k.size } )
+        attr_keys = Regexp.union(@attr_shortcut.keys.sort_by! { |k| -k.size })
         @attr_shortcut_re = /\A(#{attr_keys}+)((?:\p{Word}|-)*)/
-        tag_keys = Regexp.union((@tag_shortcut.keys - @attr_shortcut.keys).sort_by {|k| -k.size } )
+        tag_keys = Regexp.union((@tag_shortcut.keys - @attr_shortcut.keys).sort_by! { |k| -k.size })
         @tag_re = /\A(?:#{attr_keys}(?=-*\p{Word})|#{tag_keys}|\*(?=[^\s]+)|(#{word_re}(?:#{word_re}|:|-)*#{word_re}|#{word_re}+))/
       end
 


### PR DESCRIPTION
Calling `.keys()` always returns a new array, so we can use `sort_by!()` to prevent allocating a new array.