### PR TITLE
Add standard gem for linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,13 @@
+name: StandardRB
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: StandardRB Linter
+        uses: andrewmcodes/standardrb-action@v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'test-unit', '~> 3.5'
 gem 'minitest', '~> 5.15'
 gem 'rake', '~> 13.0'
 gem 'kramdown', '~> 2.4'
+gem 'standard', '~> 1.29'
 
 if ENV['TEMPLE'] && ENV['TEMPLE'] != 'master'
   gem 'temple', "= #{ENV['TEMPLE']}"


### PR DESCRIPTION
This PR only add [standard](https://github.com/standardrb/standard) to the Gemfile.

To lint, run :

```shell
standardrb
```

To lint and automatically fix, run :

```shell
standardrb --fix
```

# Applying default code style

You can see there is a major code style difference.

An example PR applies all fixes : #926

# GitHub Action

A GitHub Action exists in `.github/workflows/lint.yml` that you can run.