### PR TITLE
Support dart-sass (sass-embedded gem)

### DIFF
--- a/README.jp.md
+++ b/README.jp.md
@@ -865,8 +865,8 @@ p: markdown: Tag with **inline** markdown!
 | ruby: | なし | ショートカット | Ruby コードを埋め込むショートカット |
 | javascript: | なし | ショートカット | javascript コードを埋め込み、script タグで囲む |
 | css: | なし | ショートカット | css コードを埋め込み、style タグで囲む |
-| sass: | sass | コンパイル時 | sass コードを埋め込み、style タグで囲む |
-| scss: | sass | コンパイル時 | scss コードを埋め込み、style タグで囲む |
+| sass: | sass-embedded または sassc または sass | コンパイル時 | sass コードを埋め込み、style タグで囲む |
+| scss: | sass-embedded または sassc または sass | コンパイル時 | scss コードを埋め込み、style タグで囲む |
 | less: | less | コンパイル時 | less コードを埋め込み、style タグで囲む |
 | coffee: | coffee-script | コンパイル時 | CoffeeScript をコンパイルし、 script タグで囲む |
 | markdown: | redcarpet/rdiscount/kramdown | コンパイル時 + 展開 | Markdown をコンパイルし、テキスト中の # \{variables} を展開 |

--- a/README.md
+++ b/README.md
@@ -900,8 +900,8 @@ Supported engines:
 | ruby: | none | Shortcut | Shortcut to embed ruby code |
 | javascript: | none | Shortcut | Shortcut to embed javascript code and wrap in script tag |
 | css: | none | Shortcut | Shortcut to embed css code and wrap in style tag |
-| sass: | sass | Compile time | Embed sass code and wrap in style tag |
-| scss: | sass | Compile time | Embed scss code and wrap in style tag |
+| sass: | sass-embedded or sassc or sass | Compile time | Embed sass code and wrap in style tag |
+| scss: | sass-embedded or sassc or sass | Compile time | Embed scss code and wrap in style tag |
 | less: | less | Compile time | Embed less css code and wrap in style tag |
 | coffee: | coffee-script | Compile time | Compile coffee script code and wrap in script tag |
 | markdown: | redcarpet/rdiscount/kramdown | Compile time + Interpolation | Compile markdown code and interpolate #\{variables} in text |

--- a/lib/slim/embedded.rb
+++ b/lib/slim/embedded.rb
@@ -154,8 +154,8 @@ module Slim
 
       def tilt_render(tilt_engine, tilt_options, text)
         text = tilt_engine.new(tilt_options.merge(
-          style: options[:pretty] ? :expanded : :compressed,
-          cache: false)) { text }.render
+          style: options[:pretty] ? :expanded : :compressed
+        )) { text }.render
         text = text.chomp
         [:static, text]
       end


### PR DESCRIPTION
This PR is another attempt of #895 and #889.

sass-embedded has already been adopted by dartsass-rails, haml, jekyll, nanoc, sinatra, tilt. However, slim was left out due to disagreement over what is the interface contract between slim, tilt, and sass-embedded in #895. There are two points I want to clarify for that:

1. The tilt API has never guarantee what argument it takes, it is effectively a passthrough `tilt_engine.new(...)` -> `SassEngine.new(...)`.
2. Dart Sass (sass-embedded) is a huge breaking change, and it has a redesigned API which is completely different from Ruby Sass.

Since the maintainer of this project does not like the idea of feature detection in the previous PR, this PR implement the next best thing possible. It simply removes the unsupported `cache` option from the default options. - This is what `haml` does and nobody complains, so I think it should be fine. 
