### PR TITLE
CI: Add Rails main, too

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,3 +52,6 @@ jobs:
       - run: bundle install && bundle exec rake test:rails
         env:
           RAILS: 7.0.7
+      - run: bundle install && bundle exec rake test:rails
+        env:
+          RAILS: main


### PR DESCRIPTION
This PR adds Rails `main` to the CI build matrix, in order to test against latest.

EDIT: This also passes tests.

## Context:

So I am beginning to upgrade our app to 7.1.0.beta1, and I run into many "this is not a String, you can't + on it right here, it's an ActiveSupport::OutputBuffer"

We use Slim, which perhaps is not ready for... all this In addition, we use ViewComponent, which I hear does work with other template systems (from people who made the upgrade and didn't have issues).