### PR TITLE
CI: manage the list of Ruby versions centrally

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,18 @@ on:
   schedule:
     - cron: "0 15 * * 0"
 jobs:
+  ruby-versions:
+    uses: ruby/actions/.github/workflows/ruby_versions.yml@master
+    with:
+      engine: cruby
+      min_version: 2.5
   basic:
+    needs: ruby-versions
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby


### PR DESCRIPTION
ruby/actions is a repo with practical sets of helpers for CI.

Keeping the list of current versions up to date is hereby automated.