### PR TITLE
CI: name individual run steps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,20 +49,26 @@ jobs:
         with:
           ruby-version: 2.7
       - run: bundle install && bundle exec rake test:rails
+        name: "rake test:rails RAILS=5.2.8"
         env:
           RAILS: 5.2.8
       - run: bundle install && bundle exec rake test:rails
+        name: "rake test:rails RAILS=6.0.6"
         env:
           RAILS: 6.0.6
       - run: bundle install && bundle exec rake test:rails
+        name: "rake test:rails RAILS=6.1.7"
         env:
           RAILS: 6.1.7
       - run: bundle install && bundle exec rake test:rails
+        name: "rake test:rails RAILS=7.0.7"
         env:
           RAILS: 7.0.7
       - run: bundle install && bundle exec rake test:rails
+        name: "rake test:rails RAILS=7.1.0"
         env:
           RAILS: 7.1.0
       - run: bundle install && bundle exec rake test:rails
+        name: "rake test:rails RAILS=main"
         env:
           RAILS: main


### PR DESCRIPTION
...to make them distinct from one another.

The name is otherwise built from the "run" value.