### PR TITLE
Splat builder that works with ActionView::OutputBuffer

### DIFF
--- a/lib/slim/splat/builder.rb
+++ b/lib/slim/splat/builder.rb
@@ -35,7 +35,11 @@ module Slim
         end
         if @attrs[name]
           if delim = @options[:merge_attrs][name]
-            @attrs[name] += delim + value.to_s
+            if @attrs[name].respond_to?(:+)
+              @attrs[name] += delim + value.to_s
+            else
+              @attrs[name] << delim + value.to_s
+            end
           else
             raise("Multiple #{name} attributes specified")
           end


### PR DESCRIPTION
This sketch of "have it work with Rails 7.1" for my app, it reacts to the fact that OutputBuffer no longer derives from String.

I wanted to share this as soon as I had something that could possibly work, so I added no other long thoughts or good tests to this. I'd like feedback, thoughts, whether this can be checked at a much earlier stage, etc.