### PR TITLE
Fix splat arguments on Rails 7.1

### DIFF
--- a/lib/slim/splat/builder.rb
+++ b/lib/slim/splat/builder.rb
@@ -35,7 +35,7 @@ module Slim
         end
         if @attrs[name]
           if delim = @options[:merge_attrs][name]
-            @attrs[name] += delim + value.to_s
+            @attrs[name].concat(delim + value.to_s)
           else
             raise("Multiple #{name} attributes specified")
           end

--- a/test/rails/app/views/slim/splat_with_delimiter.slim
+++ b/test/rails/app/views/slim/splat_with_delimiter.slim
@@ -1,0 +1,1 @@
+.cute *{class: "nice"} Hello

--- a/test/rails/test/test_slim.rb
+++ b/test/rails/test/test_slim.rb
@@ -94,4 +94,9 @@ class TestSlim < ActionDispatch::IntegrationTest
     get "/slim/splat"
     assert_html "<div id=\"splat\"><splat>Hello</splat></div>"
   end
+
+  test "splat with delimiter" do
+    get "/slim/splat_with_delimiter"
+    assert_html "<div class=\"cute nice\">Hello</div>"
+  end
 end


### PR DESCRIPTION
`OutputBuffer` has been changed to not inherit from String (and using the output safety core_ext from activesupport). With that change, the `+` has been removed.

This change replaces the `+=` operator with `concat`, which is available on `String`s and `OutputBuffer`s alike.

I've added a test that fails without my patch on Rails 7.1.