### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1296,6 +1296,7 @@ Template Converters (HAML, ERB, ...):
 
 Language ports/Similar languages:
 
+* [Skimpy (Python 3 template engine inspired by Slim)](https://github.com/opensourceame/skimpy)
 * [Sliq (Slim/Liquid integration)](https://github.com/slim-template/sliq)
 * [Slm (Slim port to Javascript)](https://github.com/slm-lang/slm)
 * [Coffee script plugin for Slim](https://github.com/yury/coffee-views)


### PR DESCRIPTION
Add Skimpy, a new Python 3 template engine that was inspired by, and closely resembles, the Slim template syntax