### PR TITLE
Remove legacy less engine registration

### DIFF
--- a/README.jp.md
+++ b/README.jp.md
@@ -866,7 +866,6 @@ p: markdown: Tag with **inline** markdown!
 | css: | なし | ショートカット | css コードを埋め込み、style タグで囲む |
 | sass: | sass-embedded または sassc または sass | コンパイル時 | sass コードを埋め込み、style タグで囲む |
 | scss: | sass-embedded または sassc または sass | コンパイル時 | scss コードを埋め込み、style タグで囲む |
-| less: | less | コンパイル時 | less コードを埋め込み、style タグで囲む |
 | coffee: | coffee-script | コンパイル時 | CoffeeScript をコンパイルし、 script タグで囲む |
 | markdown: | redcarpet/rdiscount/kramdown | コンパイル時 + 展開 | Markdown をコンパイルし、テキスト中の # \{variables} を展開 |
 | textile: | redcloth | コンパイル時 + 展開 | textile をコンパイルし、テキスト中の # \{variables} を展開 |
@@ -883,7 +882,6 @@ Slim::Embedded.options[:markdown] = {auto_ids: false}
 * Javascript
 * CSS
 * CoffeeScript
-* LESS
 * SASS
 * SCSS
 

--- a/README.md
+++ b/README.md
@@ -902,7 +902,6 @@ Supported engines:
 | css: | none | Shortcut | Shortcut to embed css code and wrap in style tag |
 | sass: | sass-embedded or sassc or sass | Compile time | Embed sass code and wrap in style tag |
 | scss: | sass-embedded or sassc or sass | Compile time | Embed scss code and wrap in style tag |
-| less: | less | Compile time | Embed less css code and wrap in style tag |
 | coffee: | coffee-script | Compile time | Compile coffee script code and wrap in script tag |
 | markdown: | redcarpet/rdiscount/kramdown | Compile time + Interpolation | Compile markdown code and interpolate #\{variables} in text |
 | textile: | redcloth | Compile time + Interpolation | Compile textile code and interpolate #\{variables} in text |
@@ -918,7 +917,6 @@ You can also specify HTML attributes for the following embedded engines:
 * Javascript
 * CSS
 * CoffeeScript
-* LESS
 * SASS
 * SCSS
 

--- a/lib/slim/embedded.rb
+++ b/lib/slim/embedded.rb
@@ -234,7 +234,6 @@ module Slim
 
     # These engines are executed at compile time
     register :coffee,     JavaScriptEngine,                engine: TiltEngine
-    register :less,       TagEngine,          tag: :style, engine: TiltEngine
     register :sass,       TagEngine, :pretty, tag: :style, engine: SassEngine
     register :scss,       TagEngine, :pretty, tag: :style, engine: SassEngine
 


### PR DESCRIPTION
Hey guys, thanks for you great work!

While upgrading slim from 3.0.9 to 5.2.1 I faced kind of interesting trouble.
I have couple of custom tags in my project which name starts with `less*`. That's why slim thought that it's `less` code and tried to address it's parsing to `tilt` gem, BUT `less` was completely removed from `tilt` more than two year ago ([here](https://github.com/jeremyevans/tilt/commit/5f9381d9a87eac2df9c9a2cd195e3c6504e1a41e)).

That's why I think registration of `less` should be removed from code. What do you think?