### PR TITLE
CI: Restrict GitHub Actions workflow permissions to contents: read

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ on:
       - '**.md'
   schedule:
     - cron: "6 8 * * 0"
+permissions:
+  contents: read
 jobs:
   basic:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This Pull Request restricts GitHub Actions workflow permissions to `contents: read`.

If permissions are not explicitly defined in a GitHub Actions workflow, the workflow inherits the default permissions configured at the GitHub Organization level. Depending on the organization settings, this may result in `contents: write` being granted.
- https://docs.github.com/en/actions/tutorials/authenticate-with-github_token

Since the CI workflow only requires `contents: read`, this change explicitly sets the workflow permissions to `contents: read` to ensure the principle of least privilege and avoid unintentionally granting write access.
